### PR TITLE
Fix URL in the docs welcome page

### DIFF
--- a/app/views/docs/welcome.md.erb
+++ b/app/views/docs/welcome.md.erb
@@ -11,4 +11,4 @@ thank you for being the kind of person who reads documentation.
 
 these are still WIP, but i'll be adding more content here over time.
 
-if you want to contribute, please open a PR! they're just [markdown files](https://github.com/hackclub/identity-vault/tree/main/views/docs/) :-)
+if you want to contribute, please open a PR! they're just [markdown files](https://github.com/hackclub/identity-vault/tree/main/app/views/docs/) :-)


### PR DESCRIPTION
Was pointing to `/views/docs` instead of `/app/views/docs` so it didn't work :p