### PR TITLE
Bump schema version

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_29_180141) do
+ActiveRecord::Schema[8.0].define(version: 2025_11_26_002711) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pgcrypto"


### PR DESCRIPTION
It appears the new `return_to` column from 20251126002711_add_return_to_to_login_attempts.rb` was reflected in `schema.rb`, but the version at the top of the file wasn't updated.