### PR TITLE
Add privacy Policy that might be GDPR complient

### DIFF
--- a/app/views/docs/privacy.md.erb
+++ b/app/views/docs/privacy.md.erb
@@ -4,6 +4,8 @@ category: Legal
 order: 9
 ---
 
+**Just a heads up this is a summary of the full privacy notice below which takes preseidence.**
+
 ## Core principles:
 
 - We will never sell your data to third parties.
@@ -45,3 +47,869 @@ Only three individuals can access historical documents, and only in extreme case
 ## Slack Integration
 
 **TODO**: For Slack SAML: We will never read your DMs.
+
+***
+
+# The Hack Foundation customer privacy notice
+
+
+
+This privacy notice tells you what to expect us to do with your personal
+
+information.
+
+
+
+
+
+## Contact details
+
+
+
+**Post**
+
+
+
+8605 Santa Monica Blvd 86294, West Hollywood, CA, 90069, US
+
+
+
+**Telephone**
+
+
+
+1-855-625-4225
+
+
+
+**Email**
+
+
+
+team@hackclub.com
+
+
+
+## What information we collect, use, and why
+
+
+
+We collect or use the following information to **provide services and
+
+goods, including delivery and third party referrals**:
+
+
+
+-   Names and contact details
+
+
+
+-   Gender
+
+
+
+-   Pronoun preferences
+
+
+
+-   Addresses
+
+
+-   Date of birth
+
+
+
+-   Service use history
+
+
+
+-   Records of meetings and decisions
+
+
+
+-   Payment details (including card or bank information for transfers
+
+    and direct debits)
+
+
+
+-   Website user information (including user journeys and cookie
+
+    tracking)
+
+
+
+-   Information relating to compliments or complaints
+
+
+
+-   If your identity has been verified as a child under 18
+
+
+
+-   Graduation date from the applicable education institution and the
+
+    educational institution you attend
+
+
+
+We also collect or use the following special category information
+
+to **provide services and goods, including delivery and third party
+
+referrals:**
+
+
+
+-   Racial or ethnic origin
+
+
+
+We collect or use the following information to **receive donations or
+
+funding and organise fundraising activities**:
+
+
+
+-   Names and contact details
+
+
+
+-   Addresses
+
+
+
+-   Payment or banking details
+
+
+
+-   Donation history
+
+
+
+-   Tax payer information (for tax deductions)
+
+
+
+We collect or use the following personal information **for the
+
+prevention, detection, investigation or prosecution of crimes**:
+
+
+
+-   Names and contact information
+
+
+
+
+
+-   Customer or client accounts and records
+
+
+
+
+
+-   Financial transaction information
+
+
+
+
+
+-   Relevant information from previous investigations
+
+
+
+-   Copies of photographic ID
+
+
+
+We collect or use the following personal information for **service
+
+updates or marketing purposes**:
+
+
+
+-   Names and contact details
+
+
+
+We collect or use the following personal information for **research or
+
+archiving purposes**:
+
+
+
+-   Names and contact details
+
+
+
+
+
+-   Addresses
+
+
+
+
+
+-   Website and app user journey information
+
+
+
+We also collect or use the following special category information for
+
+**research or archiving purposes:**
+
+
+
+-   Racial or ethnic origin
+
+
+
+We collect or use the following personal information to **comply with
+
+legal requirements**:
+
+
+
+-   Name
+
+
+
+-   Contact information
+
+
+
+-   Financial transaction information
+
+
+
+-   Safeguarding information
+
+
+
+We collect or use the following personal information for **recruitment
+
+purposes**:
+
+
+
+-   Contact details (eg name, address, telephone number or personal
+
+    email address)
+
+
+
+-   Date of birth
+
+
+
+-   Copies of passports or other photo ID
+
+
+
+-   Employment history (eg job application, employment references or
+
+    secondary employment)
+
+
+
+-   Education history (eg qualifications)
+
+
+
+We also collect or use the following special category information
+
+for **recruitment purposes:**
+
+
+
+-   Racial or ethnic origin
+
+
+
+We collect or use the following personal information for **dealing with
+
+queries, complaints or claims**:
+
+
+
+-   Names and contact details
+
+
+
+-   Address
+
+
+
+-   Payment details
+
+
+
+-   Account information
+
+
+-   Purchase or service history
+
+
+
+-   Witness statements and contact details
+
+
+
+-   Relevant information from previous investigations
+
+
+
+-   Customer or client accounts and records
+
+
+
+-   Financial transaction information
+
+
+
+-   Correspondence
+
+
+
+## Lawful bases and data protection rights
+
+
+
+Under EU and UK data protection law, we must have a "lawful basis" for
+
+collecting and using your personal information. There is a list of
+
+possible [lawful
+
+bases](https://ico.org.uk/for-organisations/advice-for-small-organisations/getting-started-with-gdpr/data-protection-principles-definitions-and-key-terms/#lawfulbasis)
+
+in the EU and UK GDPR.
+
+
+
+Which lawful basis we rely on may affect your data protection rights
+
+which are set out in brief below.
+
+
+
+-   **Your right of access** - You have the right to ask us for copies
+
+    of your personal information. You can request other information such
+
+    as details about where we get personal information from and who we
+
+    share personal information with. There are some exemptions which
+
+    means you may not receive all the information you ask for.
+
+-   **Your right to rectification** - You have the right to ask us to
+
+    correct or delete personal information you think is inaccurate or
+
+    incomplete.
+
+-   **Your right to erasure** - You have the right to ask us to delete
+
+    your personal information.
+
+-   **Your right to restriction of processing** - You have the right to
+
+    ask us to limit how we can use your personal information.
+
+-   **Your right to object to processing** - You have the right to
+
+    object to the processing of your personal data.
+
+-   **Your right to data portability** - You have the right to ask that
+
+    we transfer the personal information you gave us to another
+
+    organisation, or to you. 
+
+-   **Your right to withdraw consent** -- When we use consent as our
+
+    lawful basis you have the right to withdraw your consent at any
+
+    time.
+
+
+
+If you make a request, we will aim to respond within 1 month but this may be extended by up to 2 months if the request is complex.
+
+
+
+To make a data protection rights request, please contact us using the
+
+contact details at the top of this privacy notice.
+
+
+
+Our lawful bases for the collection and use of your data
+
+
+
+Our lawful bases for collecting or using personal information to
+
+**provide services and goods, including delivery and third party
+
+referrals** are:
+
+
+
+-   Consent - we have permission from you after we gave you all the
+
+    relevant information. All of your data protection rights may apply,
+
+    except the right to object. To be clear, you do have the right to
+
+    withdraw your consent at any time.
+
+
+
+-   Contract - we have to collect or use the information so we can
+
+    enter into or carry out a contract with you. All of your data
+
+    protection rights may apply except the right to object.
+
+
+
+-   Legal obligation - we have to collect or use your information so we
+
+    can comply with the law. All of your data protection rights may
+
+    apply, except the right to erasure, the right to object and the
+
+    right to data portability.
+
+
+
+Our lawful bases for collecting or using personal information to
+
+**receive donations or funding and organise fundraising activities**
+
+are:
+
+
+
+-   Consent - we have permission from you after we gave you all the
+
+    relevant information. All of your data protection rights may apply,
+
+    except the right to object. To be clear, you do have the right to
+
+    withdraw your consent at any time.
+
+
+
+Our lawful bases for collecting or using personal information **for the
+
+prevention, detection, investigation or prosecution of crimes** are:
+
+
+
+-   Consent - we have permission from you after we gave you all the
+
+    relevant information. All of your data protection rights may apply,
+
+    except the right to object. To be clear, you do have the right to
+
+    withdraw your consent at any time.
+
+
+
+-   Legal obligation - we have to collect or use your information so we
+
+    can comply with the law. All of your data protection rights may
+
+    apply, except the right to erasure, the right to object and the
+
+    right to data portability.
+
+
+
+
+
+-   Legitimate interests - we're collecting or using your information
+
+    because it benefits you, our organisation or someone else, without
+
+    causing an undue risk of harm to anyone. All of your data protection
+
+    rights may apply, except the right to portability. Our legitimate
+
+    interests are:
+  - For the purposes of reducing fraud, waste and abuse of the
+
+        service by persons not eligible to receive sponsored projects
+
+        and grants. It is deemed that the benefits of preventing fraud,
+
+        waste, and abuse for the majority of the users of their service
+
+        outweighs the risk of funds being misused.
+
+
+ -  For protection of the children using the services. This is
+
+        deemed to outweigh impacts due to the risks associated with
+
+        children being exposed to harmful content or allowing people
+
+        known or reasonably suspected to be adults to interact with them
+
+        in a harmful manner.
+
+
+
+For more information on our use of legitimate interests as a lawful
+
+basis you can contact us using the contact details set out above.
+
+
+
+-   Vital interests - collecting or using the information is needed
+
+    when someone's physical or mental health or wellbeing is at urgent
+
+    or serious risk. This includes an urgent need for life sustaining
+
+    food, water, clothing or shelter. All of your data protection rights
+
+    may apply, except the right to object and the right to portability.
+
+
+
+Our lawful bases for collecting or using personal information for
+
+**service updates or marketing purposes** are:
+
+
+
+-   Consent - we have permission from you after we gave you all the
+
+    relevant information. All of your data protection rights may apply,
+
+    except the right to object. To be clear, you do have the right to
+
+    withdraw your consent at any time.
+
+
+
+Our lawful bases for collecting or using personal information for
+
+**research or archiving purposes** are:
+
+
+
+-   Consent - we have permission from you after we gave you all the
+
+    relevant information. All of your data protection rights may apply,
+
+    except the right to object. To be clear, you do have the right to
+
+    withdraw your consent at any time.
+
+
+
+-   Legitimate interests - we're collecting or using your information
+
+    because it benefits you, our organisation or someone else, without
+
+    causing an undue risk of harm to anyone. All of your data protection
+
+    rights may apply, except the right to portability. Our legitimate
+
+    interests are:
+
+-   To ensure that the foundations funds are accessing a diverse
+
+        proportion of children. It is deemed that this is necessary as
+
+        promoting global access to coding is the stated mission purpose
+
+        of the organisation. It is further required for the detection of
+
+        inadvertant discrimination or systematic failures of the
+
+        foundations assets and systems.
+
+
+
+-    For the purposes of reducing fraud, waste and abuse of the
+
+        service by persons not eligible to receive sponsored projects
+
+        and grants by archiving past projects for comparison with future
+
+        projects and by archiving past instances of fraud. It is deemed
+
+        that the benefits of preventing fraud, waste, and abuse for the
+
+        majority of the users of their service outweighs the risk of
+
+        funds being misused.
+
+
+
+For more information on our use of legitimate interests as a lawful
+
+basis you can contact us using the contact details set out above.
+
+
+
+Our lawful bases for collecting or using personal information to
+
+**comply with legal requirements** are:
+
+
+
+-   Consent - we have permission from you after we gave you all the
+
+    relevant information. All of your data protection rights may apply,
+
+    except the right to object. To be clear, you do have the right to
+
+    withdraw your consent at any time.
+
+
+
+-   Contract - we have to collect or use the information so we can
+
+    enter into or carry out a contract with you. All of your data
+
+    protection rights may apply except the right to object.
+
+
+
+-   Legal obligation - we have to collect or use your information so we
+
+    can comply with the law. All of your data protection rights may
+
+    apply, except the right to erasure, the right to object and the
+
+    right to data portability.
+
+
+
+-   Legitimate interests - we're collecting or using your information
+
+    because it benefits you, our organisation or someone else, without
+
+    causing an undue risk of harm to anyone. All of your data protection
+
+    rights may apply, except the right to portability. Our legitimate
+
+    interests are:
+
+
+
+-   For protection of the children using the services. This is
+
+        deemed to outweigh impacts due to the risks associated with
+
+        children being exposed to harmful content or allowing people
+
+        known or reasonably suspected to be adults to interact with them
+
+        in a harmful manner.
+
+
+-   For the purposes of reducing fraud, waste and abuse of the
+
+        service by persons not eligible to receive sponsored projects
+
+        and grants. It is deemed that the benefits of preventing fraud,
+
+        waste, and abuse for the majority of the users of their service
+
+        outweighs the risk of funds being misused.
+
+
+
+For more information on our use of legitimate interests as a lawful
+
+basis you can contact us using the contact details set out above.
+
+
+
+-   Vital interests - collecting or using the information is needed
+
+    when someone's physical or mental health or wellbeing is at urgent
+
+    or serious risk. This includes an urgent need for life sustaining
+
+    food, water, clothing or shelter. All of your data protection rights
+
+    may apply, except the right to object and the right to portability.
+
+
+
+Our lawful bases for collecting or using personal information for
+
+**recruitment purposes** are:
+
+
+
+-   Consent - we have permission from you after we gave you all the
+
+    relevant information. All of your data protection rights may apply,
+
+    except the right to object. To be clear, you do have the right to
+
+    withdraw your consent at any time.
+
+
+
+-   Contract - we have to collect or use the information so we can
+
+    enter into or carry out a contract with you. All of your data
+
+    protection rights may apply except the right to object.
+
+
+
+Our lawful bases for collecting or using personal information for
+
+**dealing with queries, complaints or claims** are:
+
+
+
+-   **Consent** - we have permission from you after we gave you all the
+
+    relevant information. All of your data protection rights may apply,
+
+    except the right to object. To be clear, you do have the right to
+
+    withdraw your consent at any time.
+
+
+
+## Where we get personal information from
+
+
+
+-   Directly from you
+
+
+
+-   Family members or carers
+
+
+
+-   Suppliers and service providers
+
+
+
+## How long we keep information
+
+
+
+We keep all information for as long as needed as to be useful this depends on the data. For ID documents this will be 120 years as there is a legitimate interest in ensuring that fraud can be effectively investigated.
+
+
+
+For more information on how long we store your personal information or
+
+the criteria we use to determine this please contact us using the
+
+details provided above. 
+
+
+
+
+
+## Who we share information with
+
+
+
+### Data processors
+
+
+
+**Finical services, etc.**
+
+
+
+These data processors do the following activities for us: They process
+
+data relating to money, grants, reimbursements, etc. They provide many
+
+of the services behind Hack Club Bank as it is virtually imposed to
+
+provide that ourselves.
+
+
+
+**Forms, databases, communications, etc.**
+
+
+
+These data processors do the following activities for us: These
+
+processors provide database storage services (Hetzner & Cloudflare),
+
+databases (airtable), and communications (the slack).
+
+**This is not a comprehensive list and there are other data processors that we share data with.**
+
+
+
+### Others we share personal information with
+
+
+
+-   Organisations we need to share information with for safeguarding
+
+    reasons
+
+
+
+-   Emergency services
+
+
+
+-   Legal bodies or authorities
+
+
+
+-   Organisations we're legally obliged to share personal information
+
+    with
+
+
+
+-   Publicly on our website, social media or other marketing and
+
+    information media.
+
+
+
+## How to complain
+
+
+
+If you have any concerns about our use of your personal data, you can
+
+make a complaint to us using the contact details at the top of this
+
+privacy notice.
+
+
+
+If you remain unhappy with how we've used your data after raising a
+
+complaint with us, you may contact the competent authority of your country.
+ If you are an EEA resident the contact details of which can be found [here](https://www.edpb.europa.eu/about-edpb/about-edpb/members_en).
+If you are a resident of the UK you may contact the information commissioner [here](ico.org.uk) or you may write to the commissioner at:
+
+Information Commissioner's Office
+
+Wycliffe House
+
+Cheshire
+
+SK9 5AF
+


### PR DESCRIPTION
I spent a good few hours researching the Hack Club data systems I then generated a policy form the ICO policy generator [here]( https://ico.org.uk/for-organisations/advice-for-small-organisations/privacy-notices-and-cookies/create-your-own-privacy-notice/privacy-notice-generator-for-staff-or-volunteers/) and modified it to be applicable to both EU and UK GDPR.

I am not a lawyer this is not legal advice. THE DOCUMENT IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.