### PR TITLE
feat(slack): set timezone from browser or country when provisioning slack users via SCIM

### DIFF
--- a/app/jobs/identity/reap_aged_out_users_job.rb
+++ b/app/jobs/identity/reap_aged_out_users_job.rb
@@ -2,7 +2,7 @@ class Identity::ReapAgedOutUsersJob < ApplicationJob
   queue_as :default
 
   def perform
-    aged_out = Identity.where(ysws_eligible: true, hq_override: [false, nil])
+    aged_out = Identity.where(ysws_eligible: true, hq_override: [ false, nil ])
                        .where("birthday <= ?", 19.years.ago.to_date)
 
     reaped_count = 0

--- a/app/services/analytics_service.rb
+++ b/app/services/analytics_service.rb
@@ -134,7 +134,7 @@ class AnalyticsService
     totals.map do |scenario, total|
       prom = promoted[scenario] || 0
       rate = total > 0 ? ((prom.to_f / total) * 100).round(1) : 0
-      [scenario || "default", { total: total, promoted: prom, rate: rate }]
+      [ scenario || "default", { total: total, promoted: prom, rate: rate } ]
     end.sort_by { |_, v| -v[:total] }.to_h
   end
 

--- a/app/services/scim_service.rb
+++ b/app/services/scim_service.rb
@@ -315,17 +315,17 @@ module SCIMService
         end
       end
 
-      # Fall back to country-based timezone
-      country_code = identity.country
-      if country_code.present?
-        begin
-          country = TZInfo::Country.get(country_code)
-          zone_id = country.zone_identifiers.first
-          return zone_id if zone_id.present?
-        rescue TZInfo::InvalidCountryCode
-          Rails.logger.warn "Invalid country code '#{country_code}' for timezone lookup"
-        end
-      end
+           # Fall back to country-based timezone
+           country_code = identity.country
+           if country_code.present?
+             begin
+               country = TZInfo::Country.get(country_code.to_s)
+               zone_id = country.zone_identifiers.first
+               return zone_id if zone_id.present?
+             rescue TZInfo::InvalidCountryCode
+               Rails.logger.warn "Invalid country code '#{country_code}' for timezone lookup"
+             end
+           end
 
       nil
     rescue => e


### PR DESCRIPTION
Prefer the user's browser-detected IANA timezone (stored on IdentitySession) when creating a Slack user via SCIM. If no browser timezone is available, fall back to a best-guess timezone for the user's country using TZInfo.