### PR TITLE
move privacy info to the top

### DIFF
--- a/app/views/shared/verifications/_document_form.html.erb
+++ b/app/views/shared/verifications/_document_form.html.erb
@@ -27,7 +27,7 @@
 
 <section class="section-card privacy-section">
   <p><strong><%= t("verifications.document.privacy_info.review_time") %></strong></p>
-  <p><strong><%= t("verifications.document.privacy_info.privacy", link: link_to(t("verifications.document.privacy_info.here", "https://docs.google.com/document/d/1PmOWqMYRmhOiTnmJOdGeMYLvRpz1_yrOLR1RZFQu368/edit?tab=t.0", target: "_blank",rel: "noopener noreferrer")) %> </strong></p>
+  <p><strong><%= t("verifications.document.privacy_info.privacy", link: link_to(t("verifications.document.privacy_info.here", "https://docs.google.com/document/d/1PmOWqMYRmhOiTnmJOdGeMYLvRpz1_yrOLR1RZFQu368/edit?tab=t.0", target: "_blank",rel: "noopener noreferrer"))) %> </strong></p>
   <p><strong><%= t("verifications.document.privacy_info.purpose") %></strong></p>
 </section>
 

--- a/app/views/shared/verifications/_document_form.html.erb
+++ b/app/views/shared/verifications/_document_form.html.erb
@@ -25,6 +25,12 @@
   </div>
 <% end %>
 
+<section class="section-card privacy-section">
+  <p><strong><%= t("verifications.document.privacy_info.review_time") %></strong></p>
+  <p><strong><%= t("verifications.document.privacy_info.privacy", link: link_to(t("verifications.document.privacy_info.here", "https://docs.google.com/document/d/1PmOWqMYRmhOiTnmJOdGeMYLvRpz1_yrOLR1RZFQu368/edit?tab=t.0", target: "_blank",rel: "noopener noreferrer")) %> </strong></p>
+  <p><strong><%= t("verifications.document.privacy_info.purpose") %></strong></p>
+</section>
+
 <%= form_with model: @document, url: local_assigns[:form_url], method: local_assigns[:form_method] || :post, local: true, multipart: true,
               html: {
                 "x-data" => "{ selectedType: '#{ @document.document_type }', transcriptFileCount: 0, studentIdFileCount: 0, governmentIdFileCount: 0, get canSubmit() { return this.selectedType === 'transcript' ? (this.transcriptFileCount >= 1 && this.studentIdFileCount >= 1) : this.governmentIdFileCount >= 1; }, submitted: false }",
@@ -137,12 +143,6 @@
       <p><%= t("verifications.document.uploading") %></p>
       <%= vite_image_tag "images/loader.gif" %>
     </div>
-  </section>
-
-  <section class="section-card privacy-section">
-    <p><strong><%= t("verifications.document.privacy_info.review_time") %></strong></p>
-    <p><strong><%= t("verifications.document.privacy_info.privacy") %></strong></p>
-    <p><strong><%= t("verifications.document.privacy_info.purpose") %></strong></p>
   </section>
 
   <div class="form-actions">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -636,7 +636,8 @@ en:
       uploading: Uploading your documents...
       privacy_info:
         review_time: "Review time: 1–2 business days"
-        privacy: "Privacy: Documents are encrypted and never shared with third parties. Access is limited to HCB staff during review, then core HQ staff for exceptional cases only."
+        privacy: "Privacy: Documents are encrypted and never shared with third parties. Access is limited to HCB staff during review, then core HQ staff for exceptional cases only. Read about how privacy is handled in more detail %{link}."
+        here: "here"
         purpose: "Purpose: Used only for age verification and preventing duplicate accounts."
       submit_documents: Submit Documents
     status:


### PR DESCRIPTION
Previously, information about privacy was hidden at the bottom of the page where it may go unnoticed or take longer to notice. As information about privacy is important (because the student is handing over sensitive information), it should go at the top.