### PR TITLE
Permit can_break_glass in backend user params

### DIFF
--- a/app/controllers/backend/users_controller.rb
+++ b/app/controllers/backend/users_controller.rb
@@ -101,7 +101,7 @@ module Backend
     end
 
     def user_params
-      params.require(:backend_user).permit(:username, :icon_url, :all_fields_access, :human_endorser, :program_manager, :manual_document_verifier, :super_admin, organized_program_ids: [])
+      params.require(:backend_user).permit(:username, :icon_url, :all_fields_access, :human_endorser, :program_manager, :manual_document_verifier, :super_admin, :can_break_glass, organized_program_ids: [])
     end
   end
 end

--- a/app/models/backend/user.rb
+++ b/app/models/backend/user.rb
@@ -49,6 +49,7 @@ module Backend
       roles << "Manual Document Verifier" if manual_document_verifier?
       roles << "Human Endorser" if human_endorser?
       roles << "All Fields Access" if all_fields_access?
+      roles << "Break Glass" if can_break_glass?
       roles.presence&.join(", ") || "None"
     end
 


### PR DESCRIPTION
The Break Glass permission is visible on the roles edit page, but rails filters it out as it's not in the controller. This small PR adds break glass to the user controller (and `pretty_roles` to display it on a user).