### PR TITLE
Store Sentry event_id (not full event) in flash

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -93,14 +93,14 @@ class ApplicationController < ActionController::Base
   end
 
   rescue_from ActiveRecord::RecordNotFound do |e|
-    event_id = Sentry.capture_exception(e)
+    event_id = Sentry.capture_exception(e)&.event_id
     flash[:error] = "sorry, couldn't find that object... (404)"
     flash[:sentry_event_id] = event_id if event_id
     redirect_to root_path unless request.path == "/"
   end
 
   rescue_from StandardError do |e|
-    event_id = Sentry.capture_exception(e)
+    event_id = Sentry.capture_exception(e)&.event_id
     flash[:error] = "Something went wrong. Please try again."
     flash[:sentry_event_id] = event_id if event_id
 

--- a/app/controllers/backend/application_controller.rb
+++ b/app/controllers/backend/application_controller.rb
@@ -96,14 +96,14 @@ module Backend
     end
 
     rescue_from Pundit::NotAuthorizedError do |e|
-      event_id = Sentry.capture_exception(e)
+      event_id = Sentry.capture_exception(e)&.event_id
       flash[:error] = "you don't seem to be authorized to do that?"
       flash[:sentry_event_id] = event_id if event_id
       redirect_to backend_root_path unless request.path == "/backend" || request.path == "/backend/"
     end
 
     rescue_from ActiveRecord::RecordNotFound do |e|
-      event_id = Sentry.capture_exception(e)
+      event_id = Sentry.capture_exception(e)&.event_id
       flash[:error] = "sorry, couldn't find that object... (404)"
       flash[:sentry_event_id] = event_id if event_id
       redirect_to backend_root_path unless request.path == "/backend" || request.path == "/backend/"


### PR DESCRIPTION
`Sentry.capture_exception` doesn't return an `event_id` string, it returns the entire `Sentry::ErrorEvent` object (stack frames, request payload, breadcrumbs, contexts, mucho contexto). that object got serialized into flash → session → cookie, ergo big cookie.

This PR fixes the `rescue_from` blocks to store the UUID instead of the entire event.