### PR TITLE
chore(stardance): upgrade everyone to full member immediately

### DIFF
--- a/app/models/onboarding_scenarios/stardance.rb
+++ b/app/models/onboarding_scenarios/stardance.rb
@@ -8,9 +8,13 @@ module OnboardingScenarios
       [ :first_name, :last_name, :primary_email, :birthday, :country ]
     end
 
-    def slack_channels = chans(:stardance_help, :identity_help, :hackatime_help, :help, :stardance_bulletin, :planet, :welcome_to_hack_club, :slack_guide)
+    def slack_user_type = :full_member
+
+    def slack_channels = chans(:stardance_help, :identity_help, :hackatime_help, :help, :stardance_bulletin, :planet, :welcome_to_hack_club, :slack_guide) + promotion_channels
 
     def promotion_channels = chans(:stardance, :library, :lounge, :welcome, :happenings, :community, :announcements)
+
+    def first_step = :welcome
 
     def logo_path = "images/stardance/logo.png"
     def background_path = "images/stardance/hero-bg.png"


### PR DESCRIPTION
Preserving promotion channels because it will break Ralsei for existing MCGs, as they will not get added to the promotion channels even after agreeing to the CoC. However, we should promote all new MCGs to full users anyway so it should not matter in the future!