### PR TITLE
fix: stardance CSS colors are broken in light mode

### DIFF
--- a/app/frontend/stylesheets/snippets/sidebar.scss
+++ b/app/frontend/stylesheets/snippets/sidebar.scss
@@ -398,6 +398,12 @@
   }
 }
 
+.scenario-stardance .page-header-centered {
+  h1 { color: #ffffff !important; }
+  p { color: rgba(255, 255, 255, 0.9) !important; }
+  .text-muted { color: rgba(255, 255, 255, 0.7) !important; }
+}
+
 // Common card and list layouts
 .card-list {
   display: grid;

--- a/app/views/layouts/logged_out.html.erb
+++ b/app/views/layouts/logged_out.html.erb
@@ -27,7 +27,7 @@
     body_style = content_for?(:body_style) ? yield(:body_style) : nil
     portal_scenario = respond_to?(:portal_onboarding_scenario) ? portal_onboarding_scenario : nil
   %>
-  <body class="<%= content_for?(:portal_wrapper) ? '' : (content_for?(:body_class) ? yield(:body_class) : 'auth-layout') %>" hx-headers='{"X-CSRF-Token": "<%= form_authenticity_token %>"}' hx-boost="false"<%= " style=\"#{body_style}\"".html_safe if body_style %>>
+  <body class="<%= [content_for?(:portal_wrapper) ? '' : (content_for?(:body_class) ? yield(:body_class) : 'auth-layout'), portal_scenario ? "scenario-#{portal_scenario.class.slug}" : ""].compact_blank.join(' ') %>" hx-headers='{"X-CSRF-Token": "<%= form_authenticity_token %>"}' hx-boost="false"<%= " style=\"#{body_style}\"".html_safe if body_style %>>
     <%= render "shared/scenario_background_style", scenario: portal_scenario %>
     <% if content_for?(:portal_wrapper) %>
       <main class="container portal-container">


### PR DESCRIPTION
what this does?

- introduces class on the <body> tag for each event that has an onboarding event (e.g., scenario-flavortown, scenario-stardance, etc.). 

- fixes broken CSS for stardance on lightmode

before:

<img width="1917" height="1073" alt="image" src="https://github.com/user-attachments/assets/988f2a2d-e77b-493e-82d5-a1d2bd812029" />

after:

<img width="1918" height="1078" alt="image" src="https://github.com/user-attachments/assets/3cf37b58-d22f-49c8-9d16-ce54023349ab" />
