### PR TITLE
Fix vouch verification authorization (STI policy misroute)

### DIFF
--- a/app/controllers/backend/identities_controller.rb
+++ b/app/controllers/backend/identities_controller.rb
@@ -150,7 +150,7 @@ module Backend
     end
 
     def new_vouch
-      authorize Verification::VouchVerification, :create?
+      authorize Verification::VouchVerification, :create?, policy_class: Verification::VouchVerificationPolicy
       add_breadcrumb "IDNT", backend_identities_path
       add_breadcrumb @identity.first_name, backend_identity_path(@identity)
       add_breadcrumb "vouch"
@@ -158,7 +158,7 @@ module Backend
     end
 
     def create_vouch
-      authorize Verification::VouchVerification, :create?
+      authorize Verification::VouchVerification, :create?, policy_class: Verification::VouchVerificationPolicy
       @vouch = @identity.vouch_verifications.build(vouch_params)
       if @vouch.save
         flash[:notice] = "Vouch verification created successfully"


### PR DESCRIPTION
## Problem

Creating a vouch verification returns **"you don't seem to be authorized to do that?"** for *everyone* — including super admins. Sentry confirms the failure:

> not allowed to **`VerificationPolicy#create?`** Verification::VouchVerification (`Pundit::NotAuthorizedError`)

## Root cause

`Verification` is an STI base class and `Verification::VouchVerification` is a subclass. When `Backend::IdentitiesController#new_vouch` / `#create_vouch` call:

```ruby
authorize Verification::VouchVerification, :create?
```

Pundit resolves the policy via `find_class_name`, which calls `subject.model_name`. For an STI subclass, `model_name` returns the **base class** name (`"Verification"`), so Pundit builds `VerificationPolicy` and never reaches `Verification::VouchVerificationPolicy`.

`VerificationPolicy` doesn't define `create?`, so it falls through to `ApplicationPolicy#create? = false` → denied for all users. The intended gate, `VouchVerificationPolicy#create? = user.super_admin?`, never runs.

## Fix

Pass `policy_class:` explicitly at both call sites so STI `model_name` resolution can't misroute it:

```ruby
authorize Verification::VouchVerification, :create?, policy_class: Verification::VouchVerificationPolicy
```

`create?` is the only method where the subclass policy diverges from `VerificationPolicy`, and it's only ever invoked with the class form in these two actions, so this is the minimal correct change.

## Testing

- [ ] Super admin can open `/backend/identities/:id/new_vouch` and create a vouch
- [ ] Non-super-admin (e.g. manual document verifier) is still denied