### PR TITLE
fix: allow editing prefilled signup email

### DIFF
--- a/app/views/identities/new.html.erb
+++ b/app/views/identities/new.html.erb
@@ -72,14 +72,7 @@
     <% if (@onboarding_scenario.form_fields & [:primary_email, :phone_number, :country]).any? || @identity.primary_email.present? %>
       <fieldset>
         <div class="grid">
-          <% if @identity.primary_email.present? %>
-            <%= form.hidden_field :primary_email, value: @identity.primary_email %>
-            <div>
-              <%= form.label :primary_email, t("identities.email") %>
-              <input type="text" value="<%= @identity.primary_email %>" disabled aria-disabled="true" autocomplete="email">
-              <small><a href="#" onclick="history.back(); return false;"><%= t("identities.new.wrong_email") %></a></small>
-            </div>
-          <% elsif @onboarding_scenario.form_fields.include?(:primary_email) %>
+          <% if @identity.primary_email.present? || @onboarding_scenario.form_fields.include?(:primary_email) %>
             <div>
               <%= form.label :primary_email, t("identities.email") %>
               <%= form.email_field :primary_email, required: true, placeholder: t("identities.email_placeholder"), autocomplete: "email", "aria-describedby": "emailHelp" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -403,7 +403,6 @@ en:
       not_necessarily_legal_name: not necessarily your legal name, what do people usually call you?
       email_code: We'll send a one-time code to this address.
       continue: Continue
-      wrong_email: "← Wrong email? Go back"
     update:
       success: saved changes!
     create:


### PR DESCRIPTION
<img width="287" height="127" alt="image" src="https://github.com/user-attachments/assets/8e314e04-946b-4262-93e1-532d6195aa21" />

Previously, the user had to go back to the page they came from which adds a bit of friction.
This is in preperation for the slack.hackclub.com rework. Since the last slide redirects to idv, the "go back" button would send the user back to the last slide and the user can't edit their email on the last slide, and it would look out of place if I did add an <input> element to let the user do that. 

GPT5.5-medium on Codex wrote all the code for me btw. I have no idea how to use RoR so I used Codex

Edit: changes were tested btw