### PR TITLE
feat: silent email prefill for trusted apps (whoami endpoint)

### DIFF
--- a/app/controllers/api/external/application_controller.rb
+++ b/app/controllers/api/external/application_controller.rb
@@ -1,6 +1,9 @@
 module API
   module External
     class ApplicationController < ActionController::API
+      # Read-only access to current_identity via the encrypted session cookie.
+      include ActionController::Cookies
+      include SessionsHelper
     end
   end
 end

--- a/app/controllers/api/external/identities_controller.rb
+++ b/app/controllers/api/external/identities_controller.rb
@@ -23,6 +23,7 @@ module API
       ].freeze
 
       before_action :set_cors_headers, only: %i[check options]
+      before_action :set_whoami_cors_headers, only: %i[whoami whoami_options]
 
       def check
         ident = if (public_id = params[:idv_id]).present?
@@ -60,7 +61,35 @@ module API
 
       def options = head :ok
 
+      def whoami
+        identity = current_identity if whoami_app
+        render json: {
+          signed_in: identity.present?,
+          email: identity&.primary_email,
+          first_name: identity&.first_name
+        }
+      end
+
+      def whoami_options = head :ok
+
       private
+
+      def whoami_app
+        return @whoami_app if defined?(@whoami_app)
+
+        origin = request.headers["Origin"]
+        @whoami_app = origin.present? ? Program.whoami_for_origin(origin).first : nil
+      end
+
+      def set_whoami_cors_headers
+        return unless whoami_app
+
+        response.set_header("Access-Control-Allow-Origin", whoami_app.whoami_allowed_origin)
+        response.set_header("Access-Control-Allow-Credentials", "true")
+        response.set_header("Access-Control-Allow-Methods", "GET, OPTIONS")
+        response.set_header("Access-Control-Allow-Headers", "Content-Type")
+        response.set_header("Vary", "Origin")
+      end
 
       def set_cors_headers
         response.set_header("Access-Control-Allow-Origin", "*")

--- a/app/controllers/developer_apps_controller.rb
+++ b/app/controllers/developer_apps_controller.rb
@@ -165,6 +165,11 @@ class DeveloperAppsController < ApplicationController
       permitted << :active
     end
 
+    if policy(@app || Program.new).update_whoami?
+      permitted << :whoami_enabled
+      permitted << :whoami_allowed_origin
+    end
+
     params.require(:program).permit(permitted)
   end
 

--- a/app/models/program.rb
+++ b/app/models/program.rb
@@ -35,6 +35,8 @@ class Program < ApplicationRecord
   audit_field :active, type: :boolean
   audit_field :byline
   audit_field :onboarding_scenario, transform: ->(v) { v&.titleize }
+  audit_field :whoami_enabled, type: :boolean
+  audit_field :whoami_allowed_origin
 
   COLLABORATOR_ACTIVITY_KEYS = %w[
     program.collaborator_invited
@@ -51,6 +53,11 @@ class Program < ApplicationRecord
   enum :trust_level, { hq_official: 0, community_untrusted: 1, community_trusted: 2 }, default: :hq_official
 
   scope :official, -> { where(trust_level: :hq_official) }
+
+  scope :whoami_for_origin, ->(origin) {
+    where(whoami_enabled: true)
+      .where("LOWER(whoami_allowed_origin) = LOWER(?)", origin.to_s.strip)
+  }
 
   AVAILABLE_SCOPES = OAuthScope::ALL.map { |s| { name: s.name, description: s.description } }.freeze
   COMMUNITY_ALLOWED_SCOPES = OAuthScope::COMMUNITY_ALLOWED

--- a/app/policies/program_policy.rb
+++ b/app/policies/program_policy.rb
@@ -59,6 +59,8 @@ class ProgramPolicy < ApplicationPolicy
 
   def update_active? = admin?
 
+  def update_whoami? = admin?
+
   def view_secret?
     owner? || admin? || collaborator?
   end

--- a/app/views/developer_apps/edit.html.erb
+++ b/app/views/developer_apps/edit.html.erb
@@ -115,7 +115,7 @@
     </div>
 
     <%# === Card 4: Admin Settings (if applicable) === %>
-    <% if policy(@app).update_byline? || policy(@app).update_onboarding_scenario? || policy(@app).update_active? %>
+    <% if policy(@app).update_byline? || policy(@app).update_onboarding_scenario? || policy(@app).update_active? || policy(@app).update_whoami? %>
       <section class="section-card">
         <h3><%= t(".admin_settings_heading", default: "Admin Settings") %></h3>
         <% if policy(@app).update_byline? %>
@@ -138,6 +138,20 @@
               <%= f.check_box :active %>
               <span><%= t(".active") %></span>
             </label>
+          </div>
+        <% end %>
+        <% if policy(@app).update_whoami? %>
+          <div class="field-group">
+            <label class="checkbox-label">
+              <%= f.check_box :whoami_enabled %>
+              <span><%= t(".whoami_enabled") %></span>
+            </label>
+            <small class="usn"><%= t(".whoami_enabled_hint") %></small>
+          </div>
+          <div class="field-group">
+            <%= f.label :whoami_allowed_origin, t(".whoami_allowed_origin") %>
+            <%= f.text_field :whoami_allowed_origin, placeholder: t(".whoami_allowed_origin_placeholder") %>
+            <small class="usn"><%= t(".whoami_allowed_origin_hint") %></small>
           </div>
         <% end %>
       </section>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -267,6 +267,11 @@ en:
       onboarding_default: "(default)"
       onboarding_scenario_hint: Users signing up through this OAuth app will use this onboarding flow
       active: Active
+      whoami_enabled: Enable silent email prefill (whoami)
+      whoami_enabled_hint: Lets the allowed site below silently read a logged-in visitor's email + first name (via /api/external/whoami) to prefill its forms. Off by default.
+      whoami_allowed_origin: Whoami allowed origin
+      whoami_allowed_origin_placeholder: https://program.hackclub.com
+      whoami_allowed_origin_hint: Exact browser Origin permitted to call whoami - scheme + host, no path or trailing slash. Only this origin receives identity.
       update: Update App
       cancel: Cancel
     create:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -414,6 +414,8 @@ Rails.application.routes.draw do
     namespace :external do
       get "/check", to: "identities#check"
       options "/check", to: "identities#options"
+      get "/whoami", to: "identities#whoami"
+      options "/whoami", to: "identities#whoami_options"
     end
   end
 

--- a/db/migrate/20260622000001_add_whoami_to_oauth_applications.rb
+++ b/db/migrate/20260622000001_add_whoami_to_oauth_applications.rb
@@ -1,0 +1,6 @@
+class AddWhoamiToOAuthApplications < ActiveRecord::Migration[8.0]
+  def change
+    add_column :oauth_applications, :whoami_enabled, :boolean, default: false, null: false
+    add_column :oauth_applications, :whoami_allowed_origin, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_27_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_06_22_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -567,6 +567,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_27_000001) do
     t.bigint "owner_identity_id"
     t.string "onboarding_scenario"
     t.string "byline"
+    t.boolean "whoami_enabled", default: false, null: false
+    t.string "whoami_allowed_origin"
     t.index ["owner_identity_id"], name: "index_oauth_applications_on_owner_identity_id"
     t.index ["program_key_bidx"], name: "index_oauth_applications_on_program_key_bidx", unique: true
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true

--- a/spec/requests/api/external/whoami_spec.rb
+++ b/spec/requests/api/external/whoami_spec.rb
@@ -1,0 +1,115 @@
+require "rails_helper"
+
+RSpec.describe "API::External::Identities#whoami", type: :request do
+  let(:origin) { "https://program.hackclub.com" }
+  let(:identity) { create(:identity, first_name: "Heidi", primary_email: "heidi@hackclub.com") }
+
+  # Stub the session cookie lookup (SessionsHelper) to isolate whoami behaviour.
+  def signed_in_as(ident)
+    allow_any_instance_of(API::External::IdentitiesController)
+      .to receive(:current_identity).and_return(ident)
+  end
+
+  context "enabled app, matching Origin" do
+    let!(:program) do
+      create(:program, whoami_enabled: true, whoami_allowed_origin: origin)
+    end
+
+    it "returns identity for a signed-in visitor with credentialed CORS headers" do
+      signed_in_as(identity)
+
+      get "/api/external/whoami", headers: { "Origin" => origin }
+
+      expect(response).to have_http_status(:ok)
+      json = JSON.parse(response.body)
+      expect(json).to eq(
+        "signed_in" => true,
+        "email" => "heidi@hackclub.com",
+        "first_name" => "Heidi"
+      )
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq(origin)
+      expect(response.headers["Access-Control-Allow-Credentials"]).to eq("true")
+      expect(response.headers["Vary"]).to include("Origin")
+    end
+
+    it "returns an inert signed-out body (still CORS-readable) when not signed in" do
+      signed_in_as(nil)
+
+      get "/api/external/whoami", headers: { "Origin" => origin }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq(
+        "signed_in" => false, "email" => nil, "first_name" => nil
+      )
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq(origin)
+    end
+
+    it "matches Origin case-insensitively" do
+      signed_in_as(identity)
+
+      get "/api/external/whoami", headers: { "Origin" => origin.upcase }
+
+      expect(JSON.parse(response.body)["signed_in"]).to be(true)
+    end
+
+    it "sets CORS headers on the OPTIONS preflight" do
+      options "/api/external/whoami", headers: { "Origin" => origin }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers["Access-Control-Allow-Origin"]).to eq(origin)
+      expect(response.headers["Access-Control-Allow-Methods"]).to include("GET")
+    end
+  end
+
+  context "app exists but feature disabled" do
+    let!(:program) do
+      create(:program, whoami_enabled: false, whoami_allowed_origin: origin)
+    end
+
+    it "never leaks identity and sends no CORS allow-origin header" do
+      signed_in_as(identity)
+
+      get "/api/external/whoami", headers: { "Origin" => origin }
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to eq(
+        "signed_in" => false, "email" => nil, "first_name" => nil
+      )
+      expect(response.headers["Access-Control-Allow-Origin"]).to be_nil
+    end
+  end
+
+  context "Origin not on any allowlist" do
+    let!(:program) do
+      create(:program, whoami_enabled: true, whoami_allowed_origin: origin)
+    end
+
+    it "returns inert body with no CORS allow-origin header" do
+      signed_in_as(identity)
+
+      get "/api/external/whoami", headers: { "Origin" => "https://evil.example.com" }
+
+      expect(JSON.parse(response.body)).to eq(
+        "signed_in" => false, "email" => nil, "first_name" => nil
+      )
+      expect(response.headers["Access-Control-Allow-Origin"]).to be_nil
+    end
+  end
+
+  context "no Origin header" do
+    let!(:program) do
+      create(:program, whoami_enabled: true, whoami_allowed_origin: origin)
+    end
+
+    it "returns inert body" do
+      signed_in_as(identity)
+
+      get "/api/external/whoami"
+
+      expect(JSON.parse(response.body)).to eq(
+        "signed_in" => false, "email" => nil, "first_name" => nil
+      )
+      expect(response.headers["Access-Control-Allow-Origin"]).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
Adds `GET /api/external/whoami` so an admin-approved, origin-allowlisted
first-party site can prefill the email box for a visitor with an HCA session
(same-site cookie, no OAuth flow).

Two new admin-gated fields on the app record:
- `whoami_enabled` - off by default
- `whoami_allowed_origin` - the one `Origin` allowed to call it

Returns `{ signed_in, email, first_name }` only on an origin match + signed-in
visitor; otherwise inert with no CORS headers. The per-app origin allowlist is
the security boundary. Reads only, no new models.
