### PR TITLE
remove scroll up reminder

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,7 +147,7 @@ GEM
     block_cipher_kit (0.0.4)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     browser (6.2.0)
     builder (3.3.0)

--- a/app/controllers/portal/verifications_controller.rb
+++ b/app/controllers/portal/verifications_controller.rb
@@ -76,7 +76,6 @@ class Portal::VerificationsController < Portal::BaseController
     setup_persona_step
     if @inquiry_already_completed
       redirect_to_portal_return(status: :pending)
-      return
     end
   end
 

--- a/app/jobs/tutorial/scroll_up_reminder_job.rb
+++ b/app/jobs/tutorial/scroll_up_reminder_job.rb
@@ -1,9 +1,0 @@
-class Tutorial::ScrollUpReminderJob < ApplicationJob
-  queue_as :default
-
-  def perform(identity)
-    return if identity.promote_click_count > 0
-
-    RalseiEngine.send_message(identity, "tutorial/scroll_up_reminder")
-  end
-end

--- a/app/services/ralsei_engine.rb
+++ b/app/services/ralsei_engine.rb
@@ -13,8 +13,6 @@ module RalseiEngine
         template = scenario.template_for(first_step)
         send_ephemeral_message(identity, template, scenario.ephemeral_channel)
       end
-
-      Tutorial::ScrollUpReminderJob.set(wait: 25.seconds).perform_later(identity)
     end
 
     def handle_tutorial_agree(identity)

--- a/app/views/slack/tutorial/scroll_up_reminder.slack_message.slocks
+++ b/app/views/slack/tutorial/scroll_up_reminder.slack_message.slocks
@@ -1,2 +1,0 @@
-section "_psst_", markdown: true
-header "Don't listen to Slackbot! Scroll up!"


### PR DESCRIPTION
Removing the reminder since the bot message doesn't go into slackbot dms but a new "bot"(?) called "Slack"

Image of "Slack"
<img width="2054" height="1574" alt="aga" src="https://github.com/user-attachments/assets/5beb29c1-7219-4937-9024-ee4fdf21aa56" />

Image of "Slackbot"
<img width="2050" height="1690" alt="aga" src="https://github.com/user-attachments/assets/24de26de-063a-43e6-a028-268e4f9c28ea" />

