### PR TITLE
feat: Multi account sessions

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,6 +9,7 @@ class ApplicationController < ActionController::Base
 
   helper_method :detected_country_alpha2
 
+  prepend_before_action :set_current_identity_session
   before_action :invalidate_v1_sessions, :authenticate_identity!, :set_honeybadger_context
 
   before_action :set_paper_trail_whodunnit
@@ -109,6 +110,10 @@ class ApplicationController < ActionController::Base
   end
 
   private
+
+  def set_current_identity_session
+    Current.identity_session = current_session
+  end
 
   def touch_session_last_seen_at = current_session&.touch_last_seen_at
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -112,7 +112,10 @@ class ApplicationController < ActionController::Base
   private
 
   def set_current_identity_session
-    Current.identity_session = current_session
+    # ||= so an explicit account selection made by an earlier prepended callback
+    # survives — see OidcAccountSelection. That selection, not the browser's
+    # active account, is what auth_time/amr/acr must describe.
+    Current.identity_session ||= current_session
   end
 
   def touch_session_last_seen_at = current_session&.touch_last_seen_at

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -37,6 +37,11 @@ class ApplicationController < ActionController::Base
     unless identity_signed_in?
       return if controller_name == "onboardings"
 
+      # The active account can expire while its siblings are still live. We never
+      # promote one silently, so send the user to pick instead of showing a login
+      # screen that makes it look like the whole browser was signed out.
+      return redirect_to browser_accounts_path if other_live_accounts_in_browser?
+
       if request.xhr?
         redirect_to welcome_path
       else
@@ -118,5 +123,16 @@ class ApplicationController < ActionController::Base
     Current.identity_session ||= current_session
   end
 
-  def touch_session_last_seen_at = current_session&.touch_last_seen_at
+  # Gated on the same flag check /accounts itself uses, so with the flag off both
+  # answer false and there is nothing to bounce between.
+  def other_live_accounts_in_browser?
+    return false unless account_chooser_available?
+
+    current_browser_session&.live_identity_sessions&.exists? || false
+  end
+
+  def touch_session_last_seen_at
+    current_session&.touch_last_seen_at
+    current_browser_session&.touch_last_seen_at
+  end
 end

--- a/app/controllers/browser_accounts_controller.rb
+++ b/app/controllers/browser_accounts_controller.rb
@@ -32,7 +32,7 @@ class BrowserAccountsController < ApplicationController
   # itself needs no knowledge of any of this.
   def add
     if current_browser_session.at_account_limit?
-      flash[:error] = "You're signed into the maximum number of accounts in this browser. Sign one out first."
+      flash[:error] = t("accounts.limit_error", max: BrowserSession::MAX_ACCOUNTS)
       return redirect_to browser_accounts_path(pending: params[:pending])
     end
 
@@ -48,6 +48,8 @@ class BrowserAccountsController < ApplicationController
     return account_not_found if target.nil?
 
     result = remove_account!(target)
+    return account_not_found if result.nil?
+
     flash[:info] = "Signed out of #{target.identity.primary_email}."
 
     if result == :signed_out
@@ -69,6 +71,12 @@ class BrowserAccountsController < ApplicationController
     end
 
     session.delete(:adding_account)
+
+    # Authenticating an account through "use another account" *is* the choice.
+    # Without recording it the replayed request resolves as ambiguous again and
+    # bounces the user straight back to the chooser they just came from.
+    remember_selection_for(pending, current_session)
+
     redirect_to rebuilt_request_path(pending), allow_other_host: false
   end
 
@@ -108,6 +116,12 @@ class BrowserAccountsController < ApplicationController
   def remember_pending_selection(identity_session)
     pending = PendingAuthorization.active.find_by(token: params[:pending])
     return if pending.nil? || pending.browser_session_id != current_browser_session.id
+
+    remember_selection_for(pending, identity_session)
+  end
+
+  def remember_selection_for(pending, identity_session)
+    return if identity_session.nil?
 
     kind, ref = client_reference_for(pending)
     return if ref.blank?

--- a/app/controllers/browser_accounts_controller.rb
+++ b/app/controllers/browser_accounts_controller.rb
@@ -1,0 +1,147 @@
+class BrowserAccountsController < ApplicationController
+  layout "logged_out"
+
+  FEATURE_FLAG = :multi_account_sessions_2026_07_24
+
+  # Reachable with no active account: signing one account out leaves the browser
+  # session alive with the others, and we never auto-promote a sibling.
+  skip_before_action :authenticate_identity!
+
+  before_action :require_browser_session
+  before_action :require_feature_flag
+
+  def index
+    @accounts = accounts
+    @pending_token = params[:pending]
+    @preselect_public_id = params[:preselect]
+    @at_account_limit = current_browser_session.at_account_limit?
+  end
+
+  def switch
+    target = find_account(params[:id])
+    return account_not_found if target.nil?
+
+    switch_account!(target)
+    remember_pending_selection(target)
+
+    resume_or(root_path)
+  end
+
+  # Leaves mid-flow to authenticate a different account, then comes back. The
+  # parked request travels as an opaque handle in return_to, so the login flow
+  # itself needs no knowledge of any of this.
+  def add
+    if current_browser_session.at_account_limit?
+      flash[:error] = "You're signed into the maximum number of accounts in this browser. Sign one out first."
+      return redirect_to browser_accounts_path(pending: params[:pending])
+    end
+
+    # Lets LoginsController#ensure_no_user! through for this flow only.
+    session[:adding_account] = true
+
+    return_to = params[:pending].present? ? resume_browser_account_path(pending: params[:pending]) : root_path
+    redirect_to login_path(return_to: return_to)
+  end
+
+  def destroy
+    target = find_account(params[:id])
+    return account_not_found if target.nil?
+
+    result = remove_account!(target)
+    flash[:info] = "Signed out of #{target.identity.primary_email}."
+
+    if result == :signed_out
+      redirect_to welcome_path
+    else
+      redirect_to browser_accounts_path
+    end
+  end
+
+  def resume
+    pending = PendingAuthorization.consume!(
+      token: params[:pending],
+      browser_session: current_browser_session
+    )
+
+    if pending.nil?
+      flash[:error] = "That sign-in request expired. Start again from the app you were signing into."
+      return redirect_to root_path
+    end
+
+    session.delete(:adding_account)
+    redirect_to rebuilt_request_path(pending), allow_other_host: false
+  end
+
+  private
+
+  def accounts
+    current_browser_session
+      .live_identity_sessions
+      .includes(:identity, :login_attempt)
+  end
+
+  def find_account(public_id)
+    return nil if public_id.blank?
+
+    accounts.find { |session| session.identity.public_id == public_id }
+  end
+
+  def account_not_found
+    flash[:error] = "That account isn't signed in on this browser."
+    redirect_to browser_accounts_path
+  end
+
+  def require_browser_session
+    return if current_browser_session&.live_identity_sessions&.exists?
+
+    redirect_to welcome_path
+  end
+
+  def require_feature_flag
+    return if Flipper.enabled?(FEATURE_FLAG, current_identity)
+
+    redirect_to root_path
+  end
+
+  # Recording the choice before resuming means the replayed request resolves to
+  # this account without needing to carry it in the URL.
+  def remember_pending_selection(identity_session)
+    pending = PendingAuthorization.active.find_by(token: params[:pending])
+    return if pending.nil? || pending.browser_session_id != current_browser_session.id
+
+    kind, ref = client_reference_for(pending)
+    return if ref.blank?
+
+    current_browser_session.remember_selection!(kind: kind, ref: ref, identity: identity_session.identity)
+  end
+
+  def client_reference_for(pending)
+    case pending.kind
+    when "oidc"
+      [ "oidc", pending.payload.dig("params", "client_id") ]
+    when "saml"
+      [ "saml", pending.payload["entity_id"] ]
+    end
+  end
+
+  def resume_or(fallback)
+    return redirect_to(resume_browser_account_path(pending: params[:pending])) if params[:pending].present?
+
+    redirect_to fallback
+  end
+
+  # Only ever rebuilds a request we parked ourselves, and only to the two
+  # endpoints that can park one.
+  def rebuilt_request_path(pending)
+    case pending.kind
+    when "oidc"
+      authorize_params = pending.payload["params"] || {}
+      "/oauth/authorize?#{authorize_params.to_query}"
+    when "saml"
+      url = pending.payload["url"].to_s
+      url.start_with?("/saml/auth") ? url : root_path
+    else
+      root_path
+    end
+  end
+end

--- a/app/controllers/browser_accounts_controller.rb
+++ b/app/controllers/browser_accounts_controller.rb
@@ -53,7 +53,7 @@ class BrowserAccountsController < ApplicationController
     if result == :signed_out
       redirect_to welcome_path
     else
-      redirect_to browser_accounts_path
+      redirect_to browser_accounts_path(pending: params[:pending])
     end
   end
 

--- a/app/controllers/concerns/oidc_account_selection.rb
+++ b/app/controllers/concerns/oidc_account_selection.rb
@@ -70,6 +70,11 @@ module OidcAccountSelection
 
     @oidc_selected_identity = identity_session.identity
     Current.identity_session = identity_session
+
+    # Step-up happens on a new request, where request-local selection is gone.
+    # Make the account that actually needs reauthentication active before the
+    # OIDC hook redirects there, otherwise step-up would verify a sibling.
+    activate_oidc_session_for_reauthentication(identity_session) if oidc_reauthentication_required?(identity_session)
   end
 
   def select_oidc_account(decision)
@@ -86,7 +91,18 @@ module OidcAccountSelection
   end
 
   def oidc_pending_payload
-    { "params" => request.request_parameters.merge(request.query_parameters).except("selected_account") }
+    authorization_params = request.request_parameters
+      .merge(request.query_parameters)
+      .except("selected_account")
+
+    prompt_values = authorization_params["prompt"].to_s.split(/ +/).reject { |value| value == "select_account" }
+    if prompt_values.empty?
+      authorization_params.delete("prompt")
+    else
+      authorization_params["prompt"] = prompt_values.join(" ")
+    end
+
+    { "params" => authorization_params }
   end
 
   # OIDC error responses belong on the client's redirect_uri, not on an HTML
@@ -109,10 +125,40 @@ module OidcAccountSelection
 
     response.headers.merge!(error_response.headers)
 
-    if params[:redirect_uri].present?
+    if oidc_error_redirect_uri_valid?
       redirect_to error_response.redirect_uri, allow_other_host: true
     else
       render json: { error: name }, status: :bad_request
     end
+  end
+
+  def oidc_error_redirect_uri_valid?
+    application = Doorkeeper.config.application_model.find_by(uid: params[:client_id])
+    return false if application.nil? || params[:redirect_uri].blank?
+
+    Doorkeeper::OAuth::Helpers::URIChecker.valid_for_authorization?(
+      params[:redirect_uri],
+      application.redirect_uri
+    )
+  end
+
+  def oidc_reauthentication_required?(identity_session)
+    return true if params[:prompt].to_s.split(/ +/).include?("login")
+
+    max_age = params[:max_age].to_s
+    max_age_seconds = max_age.to_i
+    return false unless max_age == "0" || max_age_seconds.positive?
+
+    auth_time = [ identity_session.created_at, identity_session.last_step_up_at ].compact.max
+    auth_time.nil? || (Time.zone.now - auth_time) > [ 1, max_age_seconds ].max
+  end
+
+  def activate_oidc_session_for_reauthentication(identity_session)
+    browser_session = current_browser_session
+    return if browser_session.nil? || browser_session.active_identity_session_id == identity_session.id
+
+    browser_session.activate!(identity_session)
+    @current_session = identity_session
+    self.current_identity = identity_session.identity
   end
 end

--- a/app/controllers/concerns/oidc_account_selection.rb
+++ b/app/controllers/concerns/oidc_account_selection.rb
@@ -14,6 +14,15 @@ module OidcAccountSelection
 
   CLIENT_KIND = "oidc"
 
+  # Everything the authorize endpoint (Doorkeeper plus openid_connect)
+  # understands. Parking an allowlist rather than the raw request keeps Rails
+  # form cruft — authenticity_token, commit, _method — out of the replayed URL.
+  PARKED_AUTHORIZE_PARAMS = %w[
+    client_id redirect_uri response_type response_mode scope state nonce
+    prompt max_age login_hint id_token_hint acr_values claims claims_locales
+    display ui_locales code_challenge code_challenge_method
+  ].freeze
+
   included do
     prepend_before_action :resolve_oidc_account_selection, only: [ :new, :create ]
   end
@@ -78,6 +87,12 @@ module OidcAccountSelection
   end
 
   def select_oidc_account(decision)
+    park_oidc_request_and_choose(preselect: decision.preselect_identity)
+  end
+
+  # Also the backstop for doorkeeper-openid_connect's select_account hook, which
+  # is reached only on paths this concern doesn't resolve itself.
+  def park_oidc_request_and_choose(preselect: nil)
     pending = PendingAuthorization.park!(
       browser_session: current_browser_session,
       kind: CLIENT_KIND,
@@ -86,14 +101,14 @@ module OidcAccountSelection
 
     redirect_to browser_accounts_path(
       pending: pending.token,
-      preselect: decision.preselect_identity&.public_id
+      preselect: preselect&.public_id
     )
   end
 
   def oidc_pending_payload
     authorization_params = request.request_parameters
       .merge(request.query_parameters)
-      .except("selected_account")
+      .slice(*PARKED_AUTHORIZE_PARAMS)
 
     prompt_values = authorization_params["prompt"].to_s.split(/ +/).reject { |value| value == "select_account" }
     if prompt_values.empty?
@@ -153,12 +168,13 @@ module OidcAccountSelection
     auth_time.nil? || (Time.zone.now - auth_time) > [ 1, max_age_seconds ].max
   end
 
+  # Goes through switch_account! rather than activate! so an RP-triggered change
+  # of active account rotates the cookie and lands in the audit log exactly like
+  # a user-initiated switch — it is the same observable change.
   def activate_oidc_session_for_reauthentication(identity_session)
     browser_session = current_browser_session
     return if browser_session.nil? || browser_session.active_identity_session_id == identity_session.id
 
-    browser_session.activate!(identity_session)
-    @current_session = identity_session
-    self.current_identity = identity_session.identity
+    switch_account!(identity_session)
   end
 end

--- a/app/controllers/concerns/oidc_account_selection.rb
+++ b/app/controllers/concerns/oidc_account_selection.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+# Account selection for the OIDC authorize endpoint.
+#
+# doorkeeper-openid_connect handles prompt=login and max_age for us (once
+# auth_time comes from the right session), but it has no id_token_hint support,
+# no way to return account_selection_required, and its select_account hook is
+# unconfigured — which currently makes prompt=select_account a hard error.
+#
+# This runs ahead of the gem's authenticate_resource_owner! chain: if it
+# redirects, the gem never sees the request.
+module OidcAccountSelection
+  extend ActiveSupport::Concern
+
+  CLIENT_KIND = "oidc"
+
+  included do
+    prepend_before_action :resolve_oidc_account_selection, only: [ :new, :create ]
+  end
+
+  # Consulted by Doorkeeper's resource_owner_authenticator so the grant is issued
+  # to the selected account rather than whichever one happens to be active.
+  def oidc_selected_identity
+    @oidc_selected_identity
+  end
+
+  private
+
+  def resolve_oidc_account_selection
+    return if params[:client_id].blank?
+
+    hint = IdTokenHintVerifier.call(params[:id_token_hint], audience: params[:client_id])
+    return render_oidc_selection_error(:invalid_request) if hint.invalid?
+
+    decision = AccountSelectionResolver.new(
+      browser_session: current_browser_session,
+      client_kind: CLIENT_KIND,
+      client_ref: params[:client_id],
+      prompt: params[:prompt].to_s.split(/ +/),
+      login_hint: params[:login_hint],
+      id_token_hint_subject: hint.subject
+    ).call
+
+    case decision.action
+    when :login_required
+      # Nothing signed in here: fall through to the normal unauthenticated path
+      # (resource_owner_authenticator redirects to /oauth/welcome).
+      nil
+    when :error
+      render_oidc_selection_error(decision.error)
+    when :chooser
+      return select_oidc_account(decision) if account_chooser_available?
+
+      # Chooser disabled: behave exactly as before, using the active account.
+      apply_oidc_selection(current_session)
+    when :proceed
+      # A stale tab must not approve consent for an account other than the one
+      # whose data it displayed.
+      if request.post? && params[:selected_account].present? &&
+          params[:selected_account] != decision.identity_session.identity.public_id
+        return select_oidc_account(decision)
+      end
+
+      apply_oidc_selection(decision.identity_session)
+    end
+  end
+
+  def apply_oidc_selection(identity_session)
+    return if identity_session.nil?
+
+    @oidc_selected_identity = identity_session.identity
+    Current.identity_session = identity_session
+  end
+
+  def select_oidc_account(decision)
+    pending = PendingAuthorization.park!(
+      browser_session: current_browser_session,
+      kind: CLIENT_KIND,
+      payload: oidc_pending_payload
+    )
+
+    redirect_to browser_accounts_path(
+      pending: pending.token,
+      preselect: decision.preselect_identity&.public_id
+    )
+  end
+
+  def oidc_pending_payload
+    { "params" => request.request_parameters.merge(request.query_parameters).except("selected_account") }
+  end
+
+  # OIDC error responses belong on the client's redirect_uri, not on an HTML
+  # error page — the RP has to be able to see them.
+  def render_oidc_selection_error(name)
+    error_response =
+      if name == :invalid_request
+        Doorkeeper::OAuth::InvalidRequestResponse.new(
+          name: name,
+          state: params[:state],
+          redirect_uri: params[:redirect_uri]
+        )
+      else
+        Doorkeeper::OAuth::ErrorResponse.new(
+          name: name,
+          state: params[:state],
+          redirect_uri: params[:redirect_uri]
+        )
+      end
+
+    response.headers.merge!(error_response.headers)
+
+    if params[:redirect_uri].present?
+      redirect_to error_response.redirect_uri, allow_other_host: true
+    else
+      render json: { error: name }, status: :bad_request
+    end
+  end
+end

--- a/app/controllers/concerns/saml_account_selection.rb
+++ b/app/controllers/concerns/saml_account_selection.rb
@@ -74,7 +74,7 @@ module SAMLAccountSelection
 
   # IdP-initiated can't be parked and replayed — there's no GET to come back to —
   # so the chooser is rendered inline and posts straight back to this endpoint.
-  def render_saml_inline_chooser(entity_id:)
+  def render_saml_inline_chooser(entity_id:, accounts: nil)
     decision = AccountSelectionResolver.new(
       browser_session: current_browser_session,
       client_kind: CLIENT_KIND,
@@ -82,11 +82,13 @@ module SAMLAccountSelection
       force_chooser: true
     ).call
 
-    @accounts = eligible_saml_accounts
+    @accounts = accounts || eligible_saml_accounts
     @preselect_public_id = decision.preselect_identity&.public_id
-    @submit_params = request.params.slice("slug").merge("select_account" => nil).compact
 
-    render "saml/choose_account"
+    # Same layout as the standalone chooser: this is an interstitial in a sign-in
+    # flow, not a page of the app. The default layout would wrap it in the
+    # signed-in chrome, whose sidebar has no business rendering here.
+    render "saml/choose_account", layout: "logged_out"
   end
 
   def resolve_saml_account_from_params!(entity_id:)

--- a/app/controllers/concerns/saml_account_selection.rb
+++ b/app/controllers/concerns/saml_account_selection.rb
@@ -1,0 +1,121 @@
+# frozen_string_literal: true
+
+# Account selection for the SAML IdP.
+#
+# SAML has no equivalent of prompt=select_account, so policy stands in for
+# protocol: the first SSO to a service provider from a browser holding several
+# accounts asks, and the answer is remembered per entity ID. `?select_account=1`
+# forces the question again.
+#
+# IdP-initiated flows always ask, because there is no SP request to correlate
+# against and nothing trustworthy to disambiguate with.
+module SAMLAccountSelection
+  extend ActiveSupport::Concern
+
+  CLIENT_KIND = "saml"
+
+  included do
+    helper_method :saml_identity
+  end
+
+  # The account this SSO is for. Falls back to the active account when selection
+  # doesn't apply (single account, or the chooser is off).
+  def saml_identity
+    @saml_selected_identity || current_identity
+  end
+
+  private
+
+  # Returns false when it has redirected or rendered, matching the `return unless`
+  # style the rest of SAMLController uses.
+  def resolve_saml_account!(entity_id:, force_chooser: false)
+    return true unless account_chooser_available?
+
+    decision = AccountSelectionResolver.new(
+      browser_session: current_browser_session,
+      client_kind: CLIENT_KIND,
+      client_ref: entity_id,
+      force_chooser: force_chooser || params[:select_account].present?
+    ).call
+
+    case decision.action
+    when :proceed
+      @saml_selected_identity = decision.identity_session.identity
+      true
+    when :chooser
+      park_saml_request_and_choose(entity_id: entity_id, decision: decision)
+      false
+    else
+      # :login_required is handled by SAMLController's own current_identity check.
+      true
+    end
+  end
+
+  # The chooser records the choice and activates the account, so the parked
+  # request can simply be replayed unchanged afterwards.
+  def park_saml_request_and_choose(entity_id:, decision:)
+    pending = PendingAuthorization.park!(
+      browser_session: current_browser_session,
+      kind: CLIENT_KIND,
+      payload: { "url" => request.fullpath, "entity_id" => entity_id }
+    )
+
+    redirect_to browser_accounts_path(
+      pending: pending.token,
+      preselect: decision.preselect_identity&.public_id
+    )
+  end
+
+  # IdP-initiated can't be parked and replayed — there's no GET to come back to —
+  # so the chooser is rendered inline and posts straight back to this endpoint.
+  def render_saml_inline_chooser(entity_id:)
+    decision = AccountSelectionResolver.new(
+      browser_session: current_browser_session,
+      client_kind: CLIENT_KIND,
+      client_ref: entity_id,
+      force_chooser: true
+    ).call
+
+    @accounts = eligible_saml_accounts
+    @preselect_public_id = decision.preselect_identity&.public_id
+    @submit_params = request.params.slice("slug").merge("select_account" => nil).compact
+
+    render "saml/choose_account"
+  end
+
+  def resolve_saml_account_from_params!(entity_id:)
+    return true if params[:selected_account].blank?
+
+    session_for_selection = eligible_saml_accounts.find do |ident_session|
+      ident_session.identity.public_id == params[:selected_account]
+    end
+
+    if session_for_selection.nil?
+      @error = "That account isn't signed in on this browser."
+      render :error, status: :bad_request
+      return false
+    end
+
+    @saml_selected_identity = session_for_selection.identity
+    current_browser_session&.remember_selection!(
+      kind: CLIENT_KIND, ref: entity_id, identity: session_for_selection.identity
+    )
+    true
+  end
+
+  # Offering an account the SP will reject is worse than not offering it. Filtered
+  # against the same allowed_emails list the SSO endpoints enforce.
+  def eligible_saml_accounts
+    sessions = current_browser_session&.live_identity_sessions&.includes(:identity, :login_attempt) || []
+    allowed = @sp_config&.dig(:allowed_emails)
+    return sessions.to_a if allowed.blank?
+
+    sessions.select { |ident_session| allowed.include?(ident_session.identity.primary_email) }
+  end
+
+  def saml_account_selection_needed?
+    return false unless account_chooser_available?
+
+    eligible_saml_accounts.size > 1
+  end
+end

--- a/app/controllers/concerns/saml_account_selection.rb
+++ b/app/controllers/concerns/saml_account_selection.rb
@@ -51,19 +51,25 @@ module SAMLAccountSelection
     end
   end
 
-  # The chooser records the choice and activates the account, so the parked
-  # request can simply be replayed unchanged afterwards.
+  # The chooser records the choice and activates the account. The one-shot
+  # chooser trigger is removed so replay can continue with that selection.
   def park_saml_request_and_choose(entity_id:, decision:)
     pending = PendingAuthorization.park!(
       browser_session: current_browser_session,
       kind: CLIENT_KIND,
-      payload: { "url" => request.fullpath, "entity_id" => entity_id }
+      payload: { "url" => saml_replay_url, "entity_id" => entity_id }
     )
 
     redirect_to browser_accounts_path(
       pending: pending.token,
       preselect: decision.preselect_identity&.public_id
     )
+  end
+
+  def saml_replay_url
+    replay_params = request.query_parameters.except("select_account")
+    query = replay_params.to_query
+    query.present? ? "#{request.path}?#{query}" : request.path
   end
 
   # IdP-initiated can't be parked and replayed — there's no GET to come back to —

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -292,6 +292,12 @@ class LoginsController < ApplicationController
     end
 
     def handle_post_verification_redirect
+        # /accounts/add checks the cap before sending anyone to the login form, but
+        # that check and this one are separate requests. Check again here, and
+        # rescue below for the case where a concurrent login takes the last slot
+        # in between — sign_in raises rather than evicting anyone.
+        return account_limit_reached if browser_account_limit_reached?
+
         # Only create session if authentication requirements are met
         LoginAttempt.transaction do
             @attempt.lock!
@@ -336,6 +342,24 @@ class LoginsController < ApplicationController
           redirect_to root_path
         end
         end
+    rescue SessionsHelper::AccountLimitError
+        # Lost a race with another tab after the pre-check above.
+        account_limit_reached
+    end
+
+    # Reauthenticating an account that is already here replaces its session rather
+    # than adding one, so it is never blocked by the cap.
+    def browser_account_limit_reached?
+        browser_session = current_browser_session
+        return false if browser_session.nil? || browser_session.expired?
+        return false if browser_session.identity_session_for(@identity).present?
+
+        browser_session.at_account_limit?
+    end
+
+    def account_limit_reached
+        flash[:error] = I18n.t("accounts.limit_error", max: BrowserSession::MAX_ACCOUNTS)
+        redirect_to browser_accounts_path
     end
 
     def provision_slack_on_first_login(scenario)

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -1,5 +1,6 @@
 class SAMLController < ApplicationController
   include SAMLHelper
+  include SAMLAccountSelection
 
   layout "logged_out", only: [ :welcome ]
 
@@ -31,7 +32,15 @@ class SAMLController < ApplicationController
       redirect_to saml_welcome_path(return_to: request.fullpath) and return
     end
 
-    if params[:slug] == "slack" && current_identity.disallow_slack
+    # IdP-initiated has no SP request to correlate against, so it always asks when
+    # this browser holds more than one eligible account.
+    return unless resolve_saml_account_from_params!(entity_id: @sp_config[:entity_id])
+
+    if @saml_selected_identity.nil? && saml_account_selection_needed?
+      render_saml_inline_chooser(entity_id: @sp_config[:entity_id]) and return
+    end
+
+    if params[:slug] == "slack" && saml_identity.disallow_slack
       @error = "Unable to log in right now"
       render :error, status: :forbidden and return
     end
@@ -41,16 +50,16 @@ class SAMLController < ApplicationController
     # Try to assign to Slack workspace if not yet done
     if params[:slug] == "slack"
       provision_slack_via_scim_if_needed
-      try_assign_to_slack_workspace unless current_identity.is_in_workspace
+      try_assign_to_slack_workspace unless saml_identity.is_in_workspace
     end
 
     response = build_saml_response(
-      identity: current_identity,
+      identity: saml_identity,
       sp_config: @sp_config,
       in_response_to: nil
     )
 
-    render_saml_response(saml_response: response, sp_config: @sp_config)
+    render_saml_response(saml_response: response, sp_config: @sp_config, identity: saml_identity)
   end
 
   def sp_initiated_get
@@ -63,9 +72,13 @@ class SAMLController < ApplicationController
       redirect_to saml_welcome_path(return_to: request.fullpath) and return
     end
 
+    # Selection runs before check_replay! — the request may be parked and replayed
+    # after the chooser, and marking it as seen first would break that.
+    return unless resolve_saml_account!(entity_id: @sp_config[:entity_id])
+
     return unless check_allowed_emails!
 
-    if @sp_config[:slug] == "slack" && current_identity.disallow_slack
+    if @sp_config[:slug] == "slack" && saml_identity.disallow_slack
       @error = "Unable to log in right now"
       render :error, status: :forbidden and return
     end
@@ -76,13 +89,19 @@ class SAMLController < ApplicationController
     # back to this same URL after login
     return unless check_replay!
 
+    current_browser_session&.remember_selection!(
+      kind: SAMLAccountSelection::CLIENT_KIND,
+      ref: @sp_config[:entity_id],
+      identity: saml_identity
+    )
+
     response = build_saml_response(
-      identity: current_identity,
+      identity: saml_identity,
       sp_config: @sp_config,
       in_response_to: @authn_request
     )
 
-    render_saml_response(saml_response: response, sp_config: @sp_config)
+    render_saml_response(saml_response: response, sp_config: @sp_config, identity: saml_identity)
 
   rescue SAML2::MissingMessage
     # hotfix for zach email
@@ -116,26 +135,26 @@ class SAMLController < ApplicationController
   private
 
   def provision_slack_via_scim_if_needed
-    return if current_identity.slack_id.present?
+    return if saml_identity.slack_id.present?
 
-    scenario = current_identity.onboarding_scenario_instance
+    scenario = saml_identity.onboarding_scenario_instance
 
     slack_result = SCIMService.find_or_create_user(
-      identity: current_identity,
+      identity: saml_identity,
       scenario: scenario
     )
 
     if slack_result[:success]
-      current_identity.update(slack_id: slack_result[:slack_id])
-      Rails.logger.info "Slack provisioning successful via SCIM for #{current_identity.id}: #{slack_result[:message]}"
+      saml_identity.update(slack_id: slack_result[:slack_id])
+      Rails.logger.info "Slack provisioning successful via SCIM for #{saml_identity.id}: #{slack_result[:message]}"
     else
-      Rails.logger.error "Slack provisioning failed via SCIM for #{current_identity.id}: #{slack_result[:error]}"
+      Rails.logger.error "Slack provisioning failed via SCIM for #{saml_identity.id}: #{slack_result[:error]}"
       Sentry.capture_message(
         "Slack provisioning failed via SCIM",
         level: :error,
         extra: {
-          identity_public_id: current_identity.public_id,
-          identity_email: current_identity.primary_email,
+          identity_public_id: saml_identity.public_id,
+          identity_email: saml_identity.primary_email,
           slack_error: slack_result[:error]
         }
       )
@@ -144,20 +163,20 @@ class SAMLController < ApplicationController
   end
 
   def try_assign_to_slack_workspace
-    return unless current_identity.slack_id.present?
+    return unless saml_identity.slack_id.present?
 
-    case SlackService.user_workspace_status(user_id: current_identity.slack_id)
+    case SlackService.user_workspace_status(user_id: saml_identity.slack_id)
     when :in_workspace
-      current_identity.update(is_in_workspace: true) unless current_identity.is_in_workspace
+      saml_identity.update(is_in_workspace: true) unless saml_identity.is_in_workspace
     when :not_in_workspace
-      scenario = current_identity.onboarding_scenario_instance
+      scenario = saml_identity.onboarding_scenario_instance
       return unless scenario.slack_channels.any?
 
       AssignSlackWorkspaceJob.perform_later(
-        slack_id: current_identity.slack_id,
+        slack_id: saml_identity.slack_id,
         user_type: scenario.slack_user_type,
         channel_ids: scenario.slack_channels,
-        identity_id: current_identity.id
+        identity_id: saml_identity.id
       )
     end
   end
@@ -296,9 +315,9 @@ class SAMLController < ApplicationController
 
   def check_allowed_emails!
     return true unless @sp_config[:allowed_emails].present?
-    return true unless current_identity
+    return true unless saml_identity
 
-    unless @sp_config[:allowed_emails].include?(current_identity.primary_email)
+    unless @sp_config[:allowed_emails].include?(saml_identity.primary_email)
       @error = "You are not authorized to access this service"
       render :error, status: :forbidden and return false
     end

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -21,7 +21,6 @@ class SAMLController < ApplicationController
     end
 
     return unless ensure_sp_configured!(slug: params[:slug])
-    return unless check_allowed_emails!
 
     unless @sp_config[:allow_idp_initiated]
       @error = "This SP is not configured for IdP-initiated authentication"
@@ -36,9 +35,17 @@ class SAMLController < ApplicationController
     # this browser holds more than one eligible account.
     return unless resolve_saml_account_from_params!(entity_id: @sp_config[:entity_id])
 
-    if @saml_selected_identity.nil? && saml_account_selection_needed?
-      render_saml_inline_chooser(entity_id: @sp_config[:entity_id]) and return
+    if @saml_selected_identity.nil?
+      eligible_accounts = eligible_saml_accounts
+
+      if eligible_accounts.one?
+        @saml_selected_identity = eligible_accounts.first.identity
+      elsif eligible_accounts.many?
+        render_saml_inline_chooser(entity_id: @sp_config[:entity_id]) and return
+      end
     end
+
+    return unless check_allowed_emails!
 
     if params[:slug] == "slack" && saml_identity.disallow_slack
       @error = "Unable to log in right now"

--- a/app/controllers/saml_controller.rb
+++ b/app/controllers/saml_controller.rb
@@ -41,7 +41,7 @@ class SAMLController < ApplicationController
       if eligible_accounts.one?
         @saml_selected_identity = eligible_accounts.first.identity
       elsif eligible_accounts.many?
-        render_saml_inline_chooser(entity_id: @sp_config[:entity_id]) and return
+        render_saml_inline_chooser(entity_id: @sp_config[:entity_id], accounts: eligible_accounts) and return
       end
     end
 

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,7 +1,27 @@
 class SessionsController < ApplicationController
+  # Signing out with several accounts in the browser leaves the browser session
+  # alive but with no active account, so this has to stay reachable.
+  skip_before_action :authenticate_identity!, only: [ :logout_all ]
+
   def logout
-    flash[:info] = "You've been logged out. Nice seeing you!"
-    sign_out
+    # Read the flag before signing out — afterwards there's no identity to gate on.
+    per_account = Flipper.enabled?(BrowserAccountsController::FEATURE_FLAG, current_identity)
+
+    result = per_account ? sign_out : sign_out_all_accounts
+
+    if result == :accounts_remaining
+      flash[:info] = "Signed out of that account."
+      redirect_to browser_accounts_path
+    else
+      flash[:info] = "You've been logged out. Nice seeing you!"
+      redirect_to welcome_path
+    end
+  end
+
+  def logout_all
+    sign_out_all_accounts
+
+    flash[:info] = "You've been signed out of every account in this browser."
     redirect_to welcome_path
   end
 end

--- a/app/helpers/account_monogram_helper.rb
+++ b/app/helpers/account_monogram_helper.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Identities have no avatar, and fetching one from a third party would leak an
+# email hash on every chooser render. A deterministic monogram is enough to make
+# rows visually distinct without adding an avatar pipeline or a privacy problem.
+module AccountMonogramHelper
+  HACK_CLUB_EMAIL_DOMAIN = "hackclub.com"
+
+  # Picked for adequate contrast against white monogram text in both themes.
+  MONOGRAM_COLORS = %w[
+    #2f6f4f
+    #1f5f8b
+    #5b3f9d
+    #8b2f5f
+    #8b4a1f
+    #3f5f2f
+    #1f6f6f
+    #6b2f2f
+  ].freeze
+
+  def account_monogram_initials(identity)
+    initials = [ identity.first_name, identity.last_name ]
+      .compact_blank
+      .map { |name| name.to_s.strip.first }
+      .join
+      .upcase
+
+    initials.presence || identity.primary_email.to_s.first.to_s.upcase.presence || "?"
+  end
+
+  def account_monogram_color(identity)
+    seed = Digest::SHA256.hexdigest(identity.public_id.to_s).to_i(16)
+    MONOGRAM_COLORS[seed % MONOGRAM_COLORS.size]
+  end
+
+  def hack_club_account?(identity)
+    identity.primary_email.to_s.downcase.end_with?("@#{HACK_CLUB_EMAIL_DOMAIN}")
+  end
+
+  # Distinguishing a work identity from a personal one is the whole point of the
+  # chooser, so it gets a text label rather than colour alone.
+  def account_kind_label(identity)
+    hack_club_account?(identity) ? t("accounts.kind.hack_club") : t("accounts.kind.personal")
+  end
+end

--- a/app/helpers/saml_helper.rb
+++ b/app/helpers/saml_helper.rb
@@ -27,7 +27,10 @@ module SAMLHelper
     saml_response
   end
 
-  def render_saml_response(saml_response:, sp_config:)
+  # `identity` is the account the assertion was built for, which is not always the
+  # browser's active account once several are signed in.
+  def render_saml_response(saml_response:, sp_config:, identity: current_identity)
+    @saml_identity = identity
     signed_xml = SAMLService::Signing.sign_response(saml_response)
     @saml_response = Base64.strict_encode64(signed_xml.to_s)
     @saml_acs_url = sp_config[:entity].service_providers.first.assertion_consumer_services.default.location
@@ -37,8 +40,8 @@ module SAMLHelper
       render :error, status: :bad_request and return
     end
 
-    if current_identity
-      current_identity.create_activity :saml_login, owner: current_identity, recipient: current_identity,
+    if identity
+      identity.create_activity :saml_login, owner: identity, recipient: identity,
         parameters: { service_provider: sp_config[:slug], name: sp_config[:friendly_name] }
     end
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -200,6 +200,11 @@ module SessionsHelper
           browser_session.update!(active_identity_session: nil)
         end
         browser_session.rotate_token!
+
+        # The Rails session belongs to the account that just left — fingerprint
+        # info, return_to and the rest must not follow the next account around.
+        # Only the browser session cookie survives, and it is rewritten below.
+        reset_session
         write_browser_session_cookie(browser_session)
 
         @current_browser_session = browser_session

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -49,9 +49,11 @@ module SessionsHelper
         existing = target.identity_session_for(identity)
 
         if existing
-          # Already signed into this account here — reactivate rather than
-          # stacking a duplicate session.
-          ident_session = existing
+          # This was a real authentication, not an account switch. Replace the
+          # old session so expiry, auth_time and the LoginAttempt assurance
+          # binding all describe the authentication that just completed.
+          existing.revoke!(reason: "reauthenticated")
+          ident_session = identity.sessions.create!(browser_session: target, **session_attributes)
         else
           raise AccountLimitError if target.at_account_limit?
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -2,55 +2,117 @@
 
 module SessionsHelper
   class AccountLockedError < StandardError; end
+  class AccountLimitError < StandardError; end
 
-  def sign_in(identity:, fingerprint_info: {}, impersonate: false)
+  SESSION_DURATION = 1.month
+  COOKIE_NAME = :session_token
+
+  # Signs `identity` in. By default the account joins whatever browser session
+  # this request already has, so a browser can hold several accounts at once.
+  # Pass `browser_session: nil` to deliberately start a fresh one.
+  #
+  # Signing in account B never inherits account A's authentication — B gets its
+  # own IdentitySession, with its own expiry, step-up state and login factors.
+  def sign_in(identity:, fingerprint_info: {}, browser_session: :current)
     raise(AccountLockedError, "Your HCB account has been locked.") if identity.locked?
 
     # Preserve fingerprint info from session if not passed
     fingerprint_info = session[:fingerprint_info] if fingerprint_info.blank? && session[:fingerprint_info].present?
+    fingerprint_info = (fingerprint_info || {}).with_indifferent_access
 
     # Preserve flow data before resetting session
     return_to = session[:return_to]
+
+    target = browser_session == :current ? current_browser_session : browser_session
 
     reset_session
 
     # Restore flow data after session reset
     session[:return_to] = return_to if return_to.present?
 
-    session_token = SecureRandom.urlsafe_base64
-    session_duration = 1.month
-    expires_at = session_duration.seconds.from_now
-    cookies.encrypted[:session_token] = {
-      value: session_token,
-      expires: expires_at,
-      httponly: true,
-      secure: Rails.env.production?,
-      same_site: :lax
-    }
-    cookies.encrypted[:signed_user] = {
-      value: identity.signed_id(expires_in: 2.months, purpose: :remember_me),
-      expires: 2.months.from_now,
-      httponly: true,
-      secure: Rails.env.production?,
-      same_site: :lax
-    }
-    ident_session = identity.sessions.build(
-      session_token:,
+    expires_at = SESSION_DURATION.from_now
+    session_attributes = {
+      session_token: BrowserSession.generate_token,
       fingerprint: fingerprint_info[:fingerprint],
       device_info: fingerprint_info[:device_info],
       os_info: fingerprint_info[:os_info],
       timezone: fingerprint_info[:timezone],
       ip: fingerprint_info[:ip],
-      expires_at:
-    )
+      expires_at: expires_at
+    }
 
-    ident_session.save!
+    ident_session = nil
+    added_to_existing = false
+
+    BrowserSession.transaction do
+      if target&.persisted? && !target.expired?
+        existing = target.identity_session_for(identity)
+
+        if existing
+          # Already signed into this account here — reactivate rather than
+          # stacking a duplicate session.
+          ident_session = existing
+        else
+          raise AccountLimitError if target.at_account_limit?
+
+          added_to_existing = target.live_identity_sessions.exists?
+          ident_session = identity.sessions.create!(browser_session: target, **session_attributes)
+        end
+
+        target.activate!(ident_session)
+        # Rotate on every change to the account set (session fixation).
+        target.rotate_token!
+        target.extend_expiry!(expires_at)
+      else
+        target = BrowserSession.start!(expires_at: expires_at)
+        ident_session = identity.sessions.create!(browser_session: target, **session_attributes)
+        target.activate!(ident_session)
+      end
+    end
+
+    write_browser_session_cookie(target)
+
+    if added_to_existing
+      # Deliberately does not name the other accounts in this browser: audit log
+      # entries are visible to the account they belong to.
+      ident_session.create_activity :account_added, owner: identity, recipient: identity
+    end
+
+    @current_browser_session = target
+    @current_session = ident_session
     self.current_identity = identity
 
     ident_session
   end
 
+  # Makes an account that's already signed into this browser the active one.
+  def switch_account!(identity_session)
+    browser_session = current_browser_session
+    return nil if browser_session.nil?
+    return nil unless identity_session&.live?
+    return nil unless identity_session.browser_session_id == browser_session.id
+
+    browser_session.activate!(identity_session)
+    browser_session.rotate_token!
+    write_browser_session_cookie(browser_session)
+
+    identity_session.create_activity :account_switched,
+      owner: identity_session.identity, recipient: identity_session.identity
+
+    @current_session = identity_session
+    self.current_identity = identity_session.identity
+
+    identity_session
+  end
+
+  # Set while a signed-in user is deliberately authenticating an additional
+  # account, which is the one case where reaching the login form while already
+  # signed in is intended.
+  def adding_account? = session[:adding_account].present?
+
   def ensure_no_user!
+    return if adding_account?
+
     if identity_signed_in?
       flash[:info] = "you're already logged in, silly!"
       redirect_to root_path
@@ -67,38 +129,164 @@ module SessionsHelper
     @current_identity ||= current_session&.identity
   end
 
+  def current_browser_session
+    return @current_browser_session if defined?(@current_browser_session)
+
+    token = cookies.encrypted[COOKIE_NAME]
+    return @current_browser_session = nil if token.blank?
+
+    resolution = SessionResolver.resolve(token)
+
+    @current_browser_session =
+      if resolution.nil?
+        nil
+      elsif resolution.legacy?
+        SessionResolver.adopt_legacy!(resolution.identity_session, token: token)
+      else
+        resolution.browser_session
+      end
+  end
+
+  # The account session this request is acting as. Nil when the active account
+  # has expired even though siblings are still live — we never silently promote
+  # another account, because that would change `sub` mid-session.
   def current_session
     return @current_session if defined?(@current_session)
 
-    session_token = cookies.encrypted[:session_token]
-
-    return nil if session_token.nil?
-
-    # Find a valid session (not expired) using the session token
-    @current_session = IdentitySession.not_expired.find_by(session_token:)
+    @current_session = current_browser_session&.active_session
   end
 
-  def sign_out
-    session = current_identity
-      &.sessions
-      &.find_by(session_token: cookies.encrypted[:session_token])
+  # The account a relying-party request is being authorized for. Set by
+  # OidcAccountSelection when the browser holds several accounts; otherwise the
+  # active one. Defined here rather than as a controller helper_method so views
+  # rendered outside that concern degrade sensibly instead of raising.
+  def authorizing_identity
+    @oidc_selected_identity || current_identity
+  end
 
-    if session
-      session.update(signed_out_at: Time.now, expires_at: Time.now)
-      session.create_activity :sign_out, owner: current_identity, recipient: current_identity
+  def account_chooser_available?
+    Flipper.enabled?(BrowserAccountsController::FEATURE_FLAG, current_identity)
+  end
+
+  def other_account_sessions
+    browser_session = current_browser_session
+    return IdentitySession.none if browser_session.nil?
+
+    browser_session.live_identity_sessions.where.not(id: current_session&.id)
+  end
+
+  def multiple_accounts_signed_in?
+    (current_browser_session&.account_count || 0) > 1
+  end
+
+  # Signs out one account, not the browser. Returns :accounts_remaining when
+  # other accounts are still signed in here, otherwise :signed_out.
+  def sign_out(identity_session: current_session, reason: "user_signout")
+    browser_session = current_browser_session
+    target = identity_session
+
+    if target
+      target.revoke!(reason: reason)
+      target.create_activity :sign_out, owner: target.identity, recipient: target.identity
     end
 
-    cookies.delete(:session_token)
+    if browser_session
+      browser_session.reload
+
+      if browser_session.live_identity_sessions.exists?
+        if browser_session.active_identity_session_id == target&.id
+          browser_session.update!(active_identity_session: nil)
+        end
+        browser_session.rotate_token!
+        write_browser_session_cookie(browser_session)
+
+        @current_browser_session = browser_session
+        @current_session = nil
+        self.current_identity = nil
+
+        return :accounts_remaining
+      end
+
+      browser_session.destroy!
+    end
+
+    forget_browser_session_cookie
+    @current_browser_session = nil
+    @current_session = nil
     self.current_identity = nil
 
     reset_session
+
+    :signed_out
   end
 
+  # Signs out every account in this browser and discards the browser session.
+  def sign_out_all_accounts(reason: "user_signout_all")
+    browser_session = current_browser_session
+
+    if browser_session
+      browser_session.live_identity_sessions.each do |ident_session|
+        ident_session.revoke!(reason: reason)
+        ident_session.create_activity :sign_out,
+          owner: ident_session.identity, recipient: ident_session.identity
+      end
+      browser_session.destroy!
+    end
+
+    forget_browser_session_cookie
+    @current_browser_session = nil
+    @current_session = nil
+    self.current_identity = nil
+
+    reset_session
+
+    :signed_out
+  end
+
+  # Removes an account from this browser without touching the active one.
+  def remove_account!(identity_session, reason: "user_removed")
+    browser_session = current_browser_session
+    return nil if browser_session.nil?
+    return nil unless identity_session&.browser_session_id == browser_session.id
+
+    return sign_out(identity_session: identity_session, reason: reason) if identity_session.id == current_session&.id
+
+    identity_session.revoke!(reason: reason)
+    identity_session.create_activity :account_removed,
+      owner: identity_session.identity, recipient: identity_session.identity
+
+    browser_session.rotate_token!
+    write_browser_session_cookie(browser_session)
+
+    :removed
+  end
+
+  # Every session for this identity on other devices. Distinct from the accounts
+  # held by this browser — don't conflate the two in UI.
   def sign_out_of_all_sessions(identity = current_identity)
     # Destroy all the sessions except the current session
     identity
       &.sessions
       &.where&.not(id: current_session&.id)
-      &.update_all(signed_out_at: Time.now, expires_at: Time.now)
+      &.update_all(signed_out_at: Time.now, expires_at: Time.now, revoked_reason: "user_signout_other_devices")
+  end
+
+  private
+
+  def write_browser_session_cookie(browser_session)
+    cookies.encrypted[COOKIE_NAME] = {
+      value: browser_session.token,
+      expires: browser_session.expires_at,
+      httponly: true,
+      secure: Rails.env.production?,
+      same_site: :lax
+    }
+  end
+
+  def forget_browser_session_cookie
+    cookies.delete(COOKIE_NAME)
+    # Written by an earlier implementation, never read, and previously never
+    # cleaned up on sign-out.
+    cookies.delete(:signed_user)
   end
 end

--- a/app/models/browser_session.rb
+++ b/app/models/browser_session.rb
@@ -1,0 +1,133 @@
+# A browser session is the thing the cookie points at. It owns one or more
+# IdentitySessions — one per signed-in account — and a pointer to whichever one
+# is currently active.
+#
+# Authentication assurance is deliberately NOT stored here. Expiry, step-up and
+# login factors all live on the individual IdentitySession, so signing into a
+# second account never inherits the first account's 2FA.
+class BrowserSession < ApplicationRecord
+  # A person with a work and a personal account needs two. Anything past this is
+  # not a use case we're supporting, and an unbounded list is a footgun.
+  MAX_ACCOUNTS = 5
+
+  LAST_SEEN_AT_COOLDOWN = 5.minutes
+
+  has_paper_trail skip: [ :token ]
+  has_encrypted :token
+  blind_index :token
+
+  has_many :identity_sessions, dependent: :nullify
+  belongs_to :active_identity_session, class_name: "IdentitySession", optional: true
+  has_many :client_selections, class_name: "BrowserSession::ClientSelection", dependent: :destroy
+  has_many :pending_authorizations, dependent: :destroy
+
+  validate :active_session_belongs_to_this_browser_session
+
+  scope :expired, -> { where("expires_at <= ?", Time.now) }
+  scope :not_expired, -> { where("expires_at > ?", Time.now) }
+
+  def self.generate_token = SecureRandom.urlsafe_base64
+
+  def self.start!(expires_at:)
+    create!(token: generate_token, expires_at: expires_at)
+  end
+
+  def expired? = expires_at <= Time.now
+
+  # Every account currently usable in this browser. Oldest first so the chooser
+  # order is stable as accounts come and go.
+  def live_identity_sessions
+    identity_sessions.not_expired.where(signed_out_at: nil).order(:created_at)
+  end
+
+  def live_identities
+    Identity.where(id: live_identity_sessions.select(:identity_id))
+  end
+
+  def identity_session_for(identity)
+    live_identity_sessions.find_by(identity_id: identity.id)
+  end
+
+  def account_count = live_identity_sessions.count
+
+  def at_account_limit? = account_count >= MAX_ACCOUNTS
+
+  # The active session may have expired while other accounts are still live. We
+  # never silently promote a sibling — that would change `sub` mid-session — so
+  # this returns nil and the caller sends the user to the chooser.
+  def active_session
+    session = active_identity_session
+    return nil if session.nil?
+    return nil if session.expired? || session.signed_out_at.present?
+
+    session
+  end
+
+  def active_identity = active_session&.identity
+
+  def activate!(identity_session)
+    unless identity_session.browser_session_id == id
+      raise ArgumentError, "identity session does not belong to this browser session"
+    end
+
+    update!(active_identity_session: identity_session)
+  end
+
+  # Session fixation defence: the cookie value changes whenever the set of
+  # accounts in this browser changes, without disturbing the accounts themselves.
+  def rotate_token!
+    update!(token: self.class.generate_token)
+    token
+  end
+
+  def extend_expiry!(new_expires_at)
+    return if expires_at.present? && expires_at >= new_expires_at
+
+    update!(expires_at: new_expires_at)
+  end
+
+  def touch_last_seen_at
+    return if last_seen&.after?(LAST_SEEN_AT_COOLDOWN.ago)
+
+    update_column(:last_seen, Time.current)
+  end
+
+  def selection_for(kind:, ref:)
+    client_selections.find_by(client_kind: kind.to_s, client_ref: ref.to_s)
+  end
+
+  def remember_selection!(kind:, ref:, identity:)
+    selection = client_selections.find_or_initialize_by(client_kind: kind.to_s, client_ref: ref.to_s)
+    selection.identity = identity
+    selection.last_used_at = Time.current
+    selection.save!
+    selection
+  rescue ActiveRecord::RecordNotUnique
+    # Concurrent tabs raced us to the unique index; theirs is as good as ours.
+    retry
+  end
+
+  # Sticky selections point at identities, so a remembered account may no longer
+  # have a live session here. Callers treat that as "no selection" but can still
+  # preselect it in the chooser.
+  def remembered_identity_session(kind:, ref:)
+    identity_id = selection_for(kind: kind, ref: ref)&.identity_id
+    return nil unless identity_id
+
+    live_identity_sessions.find_by(identity_id: identity_id)
+  end
+
+  def revoke_all!(reason:)
+    live_identity_sessions.each { |s| s.revoke!(reason: reason) }
+    update!(active_identity_session: nil)
+  end
+
+  private
+
+  def active_session_belongs_to_this_browser_session
+    return if active_identity_session_id.nil?
+    return if active_identity_session&.browser_session_id == id
+
+    errors.add(:active_identity_session, "must belong to this browser session")
+  end
+end

--- a/app/models/browser_session.rb
+++ b/app/models/browser_session.rb
@@ -12,7 +12,10 @@ class BrowserSession < ApplicationRecord
 
   LAST_SEEN_AT_COOLDOWN = 5.minutes
 
-  has_paper_trail skip: [ :token ]
+  # Skipping :token alone isn't enough — the columns PaperTrail actually sees are
+  # the ciphertext and the blind index, and the blind index is deterministic, so
+  # versioning it would let anyone with the versions table correlate cookies.
+  has_paper_trail skip: [ :token, :token_ciphertext, :token_bidx ]
   has_encrypted :token
   blind_index :token
 
@@ -20,6 +23,8 @@ class BrowserSession < ApplicationRecord
   belongs_to :active_identity_session, class_name: "IdentitySession", optional: true
   has_many :client_selections, class_name: "BrowserSession::ClientSelection", dependent: :destroy
   has_many :pending_authorizations, dependent: :destroy
+
+  validates :token, presence: true
 
   validate :active_session_belongs_to_this_browser_session
 
@@ -96,15 +101,32 @@ class BrowserSession < ApplicationRecord
     client_selections.find_by(client_kind: kind.to_s, client_ref: ref.to_s)
   end
 
+  # Upsert rather than find-then-save: concurrent tabs authorizing the same client
+  # would otherwise race the unique index, and a constraint violation raised
+  # inside a surrounding transaction poisons it — no rescue can recover there.
   def remember_selection!(kind:, ref:, identity:)
-    selection = client_selections.find_or_initialize_by(client_kind: kind.to_s, client_ref: ref.to_s)
-    selection.identity = identity
-    selection.last_used_at = Time.current
-    selection.save!
-    selection
-  rescue ActiveRecord::RecordNotUnique
-    # Concurrent tabs raced us to the unique index; theirs is as good as ours.
-    retry
+    kind = kind.to_s
+    ref = ref.to_s
+    raise ArgumentError, "unknown client kind #{kind}" unless ClientSelection::KINDS.include?(kind)
+
+    now = Time.current
+    ClientSelection.upsert_all(
+      [ {
+        browser_session_id: id,
+        client_kind: kind,
+        client_ref: ref,
+        identity_id: identity.id,
+        last_used_at: now,
+        created_at: now,
+        updated_at: now
+      } ],
+      unique_by: :index_client_selections_on_browser_session_and_client,
+      # updated_at is appended by Rails; naming it here too is a syntax error.
+      update_only: [ :identity_id, :last_used_at ]
+    )
+
+    client_selections.reset
+    selection_for(kind: kind, ref: ref)
   end
 
   # Sticky selections point at identities, so a remembered account may no longer

--- a/app/models/browser_session/client_selection.rb
+++ b/app/models/browser_session/client_selection.rb
@@ -1,0 +1,17 @@
+# Remembers which account a browser last used for a given relying party, so
+# returning to a tool doesn't re-prompt. Keyed by client_id for OIDC and by SP
+# entity ID for SAML.
+#
+# This is a convenience only. It never overrides prompt=select_account, an
+# id_token_hint, or a login_hint naming a different account.
+class BrowserSession::ClientSelection < ApplicationRecord
+  self.table_name = "browser_session_client_selections"
+
+  KINDS = %w[oidc saml].freeze
+
+  belongs_to :browser_session
+  belongs_to :identity
+
+  validates :client_kind, presence: true, inclusion: { in: KINDS }
+  validates :client_ref, presence: true
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Current < ActiveSupport::CurrentAttributes
+  attribute :identity_session
+end

--- a/app/models/identity_session.rb
+++ b/app/models/identity_session.rb
@@ -6,6 +6,9 @@ class IdentitySession < ApplicationRecord
   blind_index :session_token
 
   belongs_to :identity
+  # Nullable while legacy pre-multi-account sessions are still alive; they get
+  # adopted into a BrowserSession on their next request.
+  belongs_to :browser_session, optional: true
   has_one :login_attempt, foreign_key: :session_id
 
   include PublicActivity::Model
@@ -30,6 +33,56 @@ class IdentitySession < ApplicationRecord
   validate :identity_is_unlocked, on: :create
 
   def expired? = expires_at <= Time.now
+
+  def live? = !expired? && signed_out_at.nil?
+
+  def revoke!(reason: nil)
+    now = Time.now
+    update!(signed_out_at: now, expires_at: now, revoked_reason: reason)
+  end
+
+  # Authentication assurance, derived from this session's own login factors.
+  # Never from the browser session, and never from a sibling account.
+  #
+  # RFC 8176 has no value for an emailed login link/code, so it maps to `otp`
+  # alongside TOTP. Lossy, but every alternative is either a lie or a
+  # non-standard value relying parties won't recognise.
+  AMR_BY_FACTOR = {
+    "email" => "otp",
+    "legacy_email" => "otp",
+    "totp" => "otp",
+    "backup_code" => "otp",
+    "webauthn" => "hwk"
+  }.freeze
+
+  ACR_SINGLE_FACTOR = "urn:hackclub:auth:1"
+  ACR_MULTI_FACTOR = "urn:hackclub:auth:2"
+
+  def completed_authentication_factors
+    factors = login_attempt&.authentication_factors
+    return [] if factors.blank?
+
+    factors.select { |_name, satisfied| satisfied }.keys
+  end
+
+  def multi_factor? = completed_authentication_factors.size >= 2
+
+  # nil rather than a guess when there's no factor record — legacy sessions
+  # predate LoginAttempt binding, and omitting the claim is honest.
+  def amr_values
+    factors = completed_authentication_factors
+    return nil if factors.empty?
+
+    values = factors.filter_map { |factor| AMR_BY_FACTOR[factor] }.uniq
+    values << "mfa" if multi_factor?
+    values.presence
+  end
+
+  def acr_value
+    return nil if completed_authentication_factors.empty?
+
+    multi_factor? ? ACR_MULTI_FACTOR : ACR_SINGLE_FACTOR
+  end
 
   def clear_metadata!
     update!(

--- a/app/models/identity_session.rb
+++ b/app/models/identity_session.rb
@@ -1,7 +1,9 @@
 class IdentitySession < ApplicationRecord
   LAST_SEEN_AT_COOLDOWN = 5.minutes
 
-  has_paper_trail skip: [ :session_token ]
+  # :session_token alone doesn't match the real columns, and the blind index is
+  # deterministic — see BrowserSession for the same fix.
+  has_paper_trail skip: [ :session_token, :session_token_ciphertext, :session_token_bidx ]
   has_encrypted :session_token
   blind_index :session_token
 

--- a/app/models/pending_authorization.rb
+++ b/app/models/pending_authorization.rb
@@ -21,6 +21,11 @@ class PendingAuthorization < ApplicationRecord
   def self.generate_token = SecureRandom.urlsafe_base64
 
   def self.park!(browser_session:, kind:, payload:)
+    # Handles live for 15 minutes and are never read again afterwards. Reaping the
+    # browser session's own dead ones here keeps the table bounded without needing
+    # a scheduled job.
+    browser_session.pending_authorizations.where("expires_at <= ?", Time.now).delete_all
+
     create!(
       browser_session: browser_session,
       kind: kind.to_s,

--- a/app/models/pending_authorization.rb
+++ b/app/models/pending_authorization.rb
@@ -1,0 +1,55 @@
+# A parked authorization request, so "use another account" can leave the middle
+# of an OIDC or SAML flow, run a full login, and come back with every parameter
+# intact.
+#
+# The URL only ever carries the opaque handle. The request itself is encrypted at
+# rest because the payload can include a login_hint.
+class PendingAuthorization < ApplicationRecord
+  EXPIRATION = 15.minutes
+  KINDS = %w[oidc saml].freeze
+
+  has_encrypted :token
+  blind_index :token
+  has_encrypted :payload, type: :json
+
+  belongs_to :browser_session
+
+  validates :kind, presence: true, inclusion: { in: KINDS }
+
+  scope :active, -> { where(consumed_at: nil).where("expires_at > ?", Time.now) }
+
+  def self.generate_token = SecureRandom.urlsafe_base64
+
+  def self.park!(browser_session:, kind:, payload:)
+    create!(
+      browser_session: browser_session,
+      kind: kind.to_s,
+      payload: payload,
+      token: generate_token,
+      expires_at: EXPIRATION.from_now
+    )
+  end
+
+  # Single use, and only by the browser session that parked it. Both checks
+  # happen under a row lock so two tabs can't both resume the same request.
+  def self.consume!(token:, browser_session:, kind: nil)
+    return nil if token.blank? || browser_session.nil?
+
+    record = active.find_by(token: token)
+    return nil if record.nil?
+
+    record.with_lock do
+      return nil if record.consumed_at.present?
+      return nil if record.browser_session_id != browser_session.id
+      return nil if kind.present? && record.kind != kind.to_s
+
+      record.update!(consumed_at: Time.current)
+    end
+
+    record
+  end
+
+  def expired? = expires_at <= Time.now
+
+  def consumed? = consumed_at.present?
+end

--- a/app/services/account_selection_resolver.rb
+++ b/app/services/account_selection_resolver.rb
@@ -1,0 +1,103 @@
+# Decides which account a relying party request should use, given what's signed
+# into this browser plus whatever the request asked for.
+#
+# Deliberately free of HTTP so the whole decision table is unit-testable. Shared
+# by the OIDC authorize endpoint and the SAML SSO endpoint — SAML has no
+# `prompt`, so it simply passes none.
+class AccountSelectionResolver
+  # :proceed        — use decision.identity_session, no UI
+  # :chooser        — ask the user; preselect_identity is a suggestion, not a decision
+  # :login_required — nothing usable is signed in here
+  # :error          — resolve was impossible without UI (prompt=none)
+  Decision = Data.define(:action, :identity_session, :preselect_identity, :login_hint, :error) do
+    def proceed? = action == :proceed
+    def chooser? = action == :chooser
+    def login_required? = action == :login_required
+    def error? = action == :error
+  end
+
+  def initialize(browser_session:, client_kind:, client_ref:, prompt: [], login_hint: nil,
+                 id_token_hint_subject: nil, force_chooser: false)
+    @browser_session = browser_session
+    @client_kind = client_kind
+    @client_ref = client_ref
+    @prompt = Array(prompt).map(&:to_s)
+    @login_hint = login_hint.presence
+    @id_token_hint_subject = id_token_hint_subject.presence
+    @force_chooser = force_chooser
+  end
+
+  def call
+    return decide(:login_required) if candidates.empty?
+
+    # id_token_hint is an instruction, not a preference: if the named subject
+    # isn't here we must not substitute another account.
+    if @id_token_hint_subject.present?
+      return decide(:proceed, identity_session: hinted_session) if hinted_session
+      return account_selection_required if silent?
+
+      return decide(:chooser)
+    end
+
+    return chooser_decision if @force_chooser || @prompt.include?("select_account")
+
+    return decide(:proceed, identity_session: hinted_session) if hinted_session
+
+    if silent?
+      return decide(:proceed, identity_session: remembered_session) if remembered_session
+      return decide(:proceed, identity_session: candidates.first) if candidates.one?
+
+      return account_selection_required
+    end
+
+    return decide(:proceed, identity_session: candidates.first) if candidates.one?
+    return decide(:proceed, identity_session: remembered_session) if remembered_session
+
+    chooser_decision
+  end
+
+  private
+
+  def silent? = @prompt.include?("none")
+
+  def candidates
+    @candidates ||= @browser_session ? @browser_session.live_identity_sessions.to_a : []
+  end
+
+  # A login_hint that doesn't match anything here is a hint for the login form,
+  # not grounds for picking someone.
+  def hinted_session
+    return @hinted_session if defined?(@hinted_session)
+
+    @hinted_session =
+      if @id_token_hint_subject.present?
+        candidates.find { |session| session.identity.public_id == @id_token_hint_subject }
+      elsif @login_hint.present?
+        normalized = @login_hint.to_s.strip.downcase
+        candidates.find { |session| session.identity.primary_email.to_s.downcase == normalized }
+      end
+  end
+
+  def remembered_session
+    return @remembered_session if defined?(@remembered_session)
+
+    @remembered_session =
+      @browser_session&.remembered_identity_session(kind: @client_kind, ref: @client_ref)
+  end
+
+  def chooser_decision
+    decide(:chooser, preselect_identity: (hinted_session || remembered_session)&.identity)
+  end
+
+  def account_selection_required = decide(:error, error: :account_selection_required)
+
+  def decide(action, identity_session: nil, preselect_identity: nil, error: nil)
+    Decision.new(
+      action: action,
+      identity_session: identity_session,
+      preselect_identity: preselect_identity,
+      login_hint: @login_hint,
+      error: error
+    )
+  end
+end

--- a/app/services/account_selection_resolver.rb
+++ b/app/services/account_selection_resolver.rb
@@ -41,7 +41,16 @@ class AccountSelectionResolver
 
     return chooser_decision if @force_chooser || @prompt.include?("select_account")
 
-    return decide(:proceed, identity_session: hinted_session) if hinted_session
+    # A login_hint naming an account that isn't signed in here is still a
+    # statement about who the RP expects. Consenting as whoever happens to be
+    # signed in would hand over the wrong account without ever saying so, even
+    # when that's the only account — so ask (or, when we can't ask, say why).
+    if @login_hint.present?
+      return decide(:proceed, identity_session: hinted_session) if hinted_session
+      return account_selection_required if silent?
+
+      return decide(:chooser)
+    end
 
     if silent?
       return decide(:proceed, identity_session: remembered_session) if remembered_session

--- a/app/services/id_token_hint_verifier.rb
+++ b/app/services/id_token_hint_verifier.rb
@@ -1,0 +1,62 @@
+# Verifies an `id_token_hint` we issued and extracts its subject.
+#
+# Signature and issuer are checked; expiry deliberately is not — OIDC Core
+# requires that an expired ID token still be accepted as a hint, which is the
+# normal case (the RP is telling us who the user was last time).
+class IdTokenHintVerifier
+  Result = Data.define(:subject, :error) do
+    def present? = subject.present?
+    def invalid? = error.present?
+  end
+
+  class << self
+    def call(hint, audience: nil)
+      return Result.new(subject: nil, error: nil) if hint.blank?
+
+      payload = decode(hint)
+      return Result.new(subject: nil, error: :invalid_request) if payload.nil?
+      return Result.new(subject: nil, error: :invalid_request) unless issuer_matches?(payload)
+      return Result.new(subject: nil, error: :invalid_request) unless audience_matches?(payload, audience)
+
+      subject = payload["sub"].presence
+      return Result.new(subject: nil, error: :invalid_request) if subject.nil?
+
+      Result.new(subject: subject, error: nil)
+    end
+
+    private
+
+    def decode(hint)
+      key = Doorkeeper::OpenidConnect.signing_key
+      return nil if key.nil?
+
+      JWT.decode(
+        hint,
+        key.keypair.public_key,
+        true,
+        algorithm: Doorkeeper::OpenidConnect.signing_algorithm.to_s.upcase,
+        verify_expiration: false,
+        verify_iat: false
+      ).first
+    rescue JWT::DecodeError, NoMethodError
+      nil
+    end
+
+    def issuer_matches?(payload)
+      payload["iss"].to_s == expected_issuer
+    end
+
+    # An RP handing us another client's ID token has no business steering our
+    # account selection.
+    def audience_matches?(payload, audience)
+      return true if audience.blank?
+
+      Array(payload["aud"]).include?(audience.to_s)
+    end
+
+    def expected_issuer
+      configured = Doorkeeper::OpenidConnect.configuration.issuer
+      configured.respond_to?(:call) ? configured.call(nil, nil).to_s : configured.to_s
+    end
+  end
+end

--- a/app/services/session_resolver.rb
+++ b/app/services/session_resolver.rb
@@ -1,0 +1,61 @@
+# Turns the value of the session cookie into a browser session and the account
+# session it currently points at.
+#
+# Shared by SessionsHelper and the SuperAdminConstraint in routes.rb so there is
+# exactly one definition of "who is this cookie". `resolve` never writes;
+# adopting a legacy session into a BrowserSession is a separate, explicit step.
+class SessionResolver
+  Resolution = Data.define(:browser_session, :identity_session, :legacy) do
+    def legacy? = legacy
+  end
+
+  class << self
+    def resolve(token)
+      return nil if token.blank?
+
+      browser_session = BrowserSession.not_expired.find_by(token: token)
+      if browser_session
+        return Resolution.new(
+          browser_session: browser_session,
+          identity_session: browser_session.active_session,
+          legacy: false
+        )
+      end
+
+      legacy_session = legacy_identity_session(token)
+      return nil if legacy_session.nil?
+
+      Resolution.new(browser_session: nil, identity_session: legacy_session, legacy: true)
+    end
+
+    # Read-only convenience for callers that only want the account (e.g. routing
+    # constraints, which must not write).
+    def identity_session(token) = resolve(token)&.identity_session
+
+    # Cookies minted before browser sessions existed hold an IdentitySession
+    # token directly. They keep working, and are adopted on next request.
+    def legacy_identity_session(token)
+      IdentitySession
+        .not_expired
+        .where(browser_session_id: nil, signed_out_at: nil)
+        .find_by(session_token: token)
+    end
+
+    # Adopts a legacy session, reusing the cookie value as the browser session
+    # token so nobody is logged out and no Set-Cookie is needed.
+    def adopt_legacy!(identity_session, token:)
+      BrowserSession.transaction do
+        browser_session = BrowserSession.create!(
+          token: token,
+          expires_at: identity_session.expires_at || SessionsHelper::SESSION_DURATION.from_now
+        )
+        identity_session.update!(browser_session: browser_session)
+        browser_session.activate!(identity_session)
+        browser_session
+      end
+    rescue ActiveRecord::RecordNotUnique
+      # A concurrent request in another tab adopted it first. Theirs is fine.
+      BrowserSession.not_expired.find_by(token: token)
+    end
+  end
+end

--- a/app/views/browser_accounts/_account_list.html.erb
+++ b/app/views/browser_accounts/_account_list.html.erb
@@ -1,0 +1,17 @@
+<%#
+  Shared by the standalone chooser and the SAML inline chooser.
+  Locals: accounts, submit_url, hidden_params, removable, preselect_public_id
+%>
+<div class="account-list" style="display: flex; flex-direction: column; gap: 0.75rem; margin: 1.5rem 0;">
+  <% accounts.each do |account| %>
+    <div class="account-list-item">
+      <%= render "browser_accounts/account_row",
+            account: account,
+            submit_url: submit_url,
+            hidden_params: local_assigns[:hidden_params] || {},
+            removable: local_assigns.fetch(:removable, false),
+            field_name: local_assigns.fetch(:field_name, :id),
+            preselect_public_id: local_assigns[:preselect_public_id] %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/browser_accounts/_account_row.html.erb
+++ b/app/views/browser_accounts/_account_row.html.erb
@@ -54,6 +54,7 @@
   <%= button_to t("accounts.remove"),
         browser_account_path(id: identity.public_id),
         method: :delete,
+        params: { pending: (local_assigns[:hidden_params] || {})[:pending] }.compact,
         class: "secondary delete account-row-remove",
         form: { data: { turbo_confirm: t("accounts.remove_confirm", email: identity.primary_email) } } %>
 <% end %>

--- a/app/views/browser_accounts/_account_row.html.erb
+++ b/app/views/browser_accounts/_account_row.html.erb
@@ -1,0 +1,59 @@
+<%#
+  Every field here is load-bearing: two accounts belonging to the same person are
+  the hardest thing to tell apart, and the full email is the only reliable
+  discriminator. Do not truncate it.
+
+  Locals: account, submit_url, hidden_params (hash), removable (bool),
+          field_name (param the chosen account's public id is submitted as)
+%>
+<% identity = account.identity %>
+<% is_active = current_session&.id == account.id %>
+<% is_preselected = local_assigns[:preselect_public_id].present? && local_assigns[:preselect_public_id] == identity.public_id %>
+
+<%= form_tag submit_url, method: :post, class: "account-row-form" do %>
+  <% (local_assigns[:hidden_params] || {}).each do |name, value| %>
+    <%= hidden_field_tag name, value, id: nil %>
+  <% end %>
+  <%= hidden_field_tag local_assigns.fetch(:field_name, :id), identity.public_id, id: nil %>
+
+  <button type="submit"
+          class="account-row<%= ' account-row--preselected' if is_preselected %>"
+          style="display: flex; align-items: center; gap: 0.75rem; width: 100%; text-align: left; cursor: pointer;">
+    <span aria-hidden="true"
+          style="background: <%= account_monogram_color(identity) %>; color: #fff; width: 2.5rem; height: 2.5rem; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: 600; flex-shrink: 0;">
+      <%= account_monogram_initials(identity) %>
+    </span>
+
+    <span style="flex: 1; min-width: 0;">
+      <span style="display: block; font-weight: 600;">
+        <%= identity.full_name.presence || identity.primary_email %>
+      </span>
+      <span class="account-email" style="display: block; word-break: break-all;">
+        <%= identity.primary_email %>
+      </span>
+      <span style="display: block; margin-top: 0.25rem;">
+        <span class="account-chip <%= hack_club_account?(identity) ? 'account-chip--work' : 'account-chip--personal' %>">
+          <%= account_kind_label(identity) %>
+        </span>
+        <% unless account.multi_factor? %>
+          <span class="account-chip account-chip--warning"><%= t("accounts.single_factor") %></span>
+        <% end %>
+        <% if is_active %>
+          <span class="account-chip account-chip--active"><%= t("accounts.active") %></span>
+        <% end %>
+      </span>
+    </span>
+
+    <span style="flex-shrink: 0; text-align: right;">
+      <small><%= t("accounts.last_used", when: time_ago_in_words(account.last_seen || account.created_at)) %></small>
+    </span>
+  </button>
+<% end %>
+
+<% if local_assigns.fetch(:removable, false) %>
+  <%= button_to t("accounts.remove"),
+        browser_account_path(id: identity.public_id),
+        method: :delete,
+        class: "secondary delete account-row-remove",
+        form: { data: { turbo_confirm: t("accounts.remove_confirm", email: identity.primary_email) } } %>
+<% end %>

--- a/app/views/browser_accounts/index.html.erb
+++ b/app/views/browser_accounts/index.html.erb
@@ -1,0 +1,36 @@
+<% content_for :title, t("accounts.title") %>
+<div class="auth-container">
+  <div class="auth-brand">
+    <%= vite_image_tag "images/hc-square.png", alt: "Hack Club logo", class: "brand-logo" %>
+    <span class="brand-text"><%= t("brand") %></span>
+  </div>
+
+  <div class="auth-card">
+    <header>
+      <h1><%= t("accounts.title") %></h1>
+      <small><%= t("accounts.subtitle") %></small>
+    </header>
+
+    <%= render "browser_accounts/account_list",
+          accounts: @accounts,
+          submit_url: switch_browser_account_path,
+          hidden_params: { pending: @pending_token }.compact_blank,
+          removable: true,
+          preselect_public_id: @preselect_public_id %>
+
+    <% if @at_account_limit %>
+      <%= render Components::Banner.new(kind: :warning) do %>
+        <%= t("accounts.limit_reached", max: BrowserSession::MAX_ACCOUNTS) %>
+      <% end %>
+    <% else %>
+      <%= button_to t("accounts.use_another"),
+            add_browser_account_path(pending: @pending_token),
+            method: :post,
+            class: "secondary" %>
+    <% end %>
+
+    <div style="margin-top: 1.5rem;">
+      <%= button_to t("accounts.sign_out_all"), logout_all_path, method: :delete, class: "secondary delete" %>
+    </div>
+  </div>
+</div>

--- a/app/views/doorkeeper/authorizations/new.html.erb
+++ b/app/views/doorkeeper/authorizations/new.html.erb
@@ -1,7 +1,11 @@
 <%
   application = Program.find_by(uid: @pre_auth.client.uid)
   scenario_class = application&.onboarding_scenario_class
-  scenario = scenario_class&.new(current_identity)
+  # authorizing_identity, not current_identity: with several accounts in this
+  # browser they can differ, and everything below must describe the account that
+  # is about to be handed over.
+  consent_identity = authorizing_identity
+  scenario = scenario_class&.new(consent_identity)
   custom_logo_path = scenario&.logo_path
 %>
 <% content_for :title, "Authorize #{@pre_auth.client.name}" %>
@@ -28,11 +32,32 @@
       <% end %>
     </header>
 
+    <% if consent_identity %>
+      <div class="oauth-identity" style="display: flex; align-items: center; gap: 0.75rem; margin: 1rem 0;">
+        <span aria-hidden="true"
+              style="background: <%= account_monogram_color(consent_identity) %>; color: #fff; width: 2.25rem; height: 2.25rem; border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: 600; flex-shrink: 0;">
+          <%= account_monogram_initials(consent_identity) %>
+        </span>
+        <span style="flex: 1; min-width: 0;">
+          <small style="display: block;"><%= t('accounts.signing_in_as') %></small>
+          <span style="display: block; word-break: break-all;"><%= consent_identity.primary_email %></span>
+          <span class="account-chip <%= hack_club_account?(consent_identity) ? 'account-chip--work' : 'account-chip--personal' %>">
+            <%= account_kind_label(consent_identity) %>
+          </span>
+        </span>
+        <% if account_chooser_available? %>
+          <%= link_to t('accounts.switch'),
+                oauth_authorization_path(request.query_parameters.merge(prompt: 'select_account')),
+                class: "secondary" %>
+        <% end %>
+      </div>
+    <% end %>
+
     <% if @pre_auth.scopes.count > 0 %>
       <%
         scopes = @pre_auth.scopes.map(&:to_s)
         not_set = t('.data.not_set')
-        scope_data = OAuthScope.consent_data_by_scope(scopes, current_identity)
+        scope_data = OAuthScope.consent_data_by_scope(scopes, consent_identity)
         unknown_scopes = scopes.reject { |s| OAuthScope.known?(s) }
       %>
 
@@ -93,6 +118,16 @@
         <%= hidden_field_tag :nonce, @pre_auth.nonce, id: nil %>
         <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
         <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+        <%# Hints have to survive the round-trip or max_age/id_token_hint silently
+            stop applying once the user clicks. `prompt` is deliberately NOT
+            re-posted: re-sending select_account or consent would loop forever. %>
+        <%= hidden_field_tag :max_age, params[:max_age], id: nil if params[:max_age].present? %>
+        <%= hidden_field_tag :login_hint, params[:login_hint], id: nil if params[:login_hint].present? %>
+        <%= hidden_field_tag :id_token_hint, params[:id_token_hint], id: nil if params[:id_token_hint].present? %>
+        <%= hidden_field_tag :acr_values, params[:acr_values], id: nil if params[:acr_values].present? %>
+        <%# Binds this consent to the account whose data is displayed above, so a
+            stale tab can't approve for a different account. %>
+        <%= hidden_field_tag :selected_account, consent_identity&.public_id, id: nil %>
         <%= submit_tag t('.deny'), class: "secondary delete" %>
       <% end %>
 
@@ -106,6 +141,16 @@
         <%= hidden_field_tag :nonce, @pre_auth.nonce, id: nil %>
         <%= hidden_field_tag :code_challenge, @pre_auth.code_challenge, id: nil %>
         <%= hidden_field_tag :code_challenge_method, @pre_auth.code_challenge_method, id: nil %>
+        <%# Hints have to survive the round-trip or max_age/id_token_hint silently
+            stop applying once the user clicks. `prompt` is deliberately NOT
+            re-posted: re-sending select_account or consent would loop forever. %>
+        <%= hidden_field_tag :max_age, params[:max_age], id: nil if params[:max_age].present? %>
+        <%= hidden_field_tag :login_hint, params[:login_hint], id: nil if params[:login_hint].present? %>
+        <%= hidden_field_tag :id_token_hint, params[:id_token_hint], id: nil if params[:id_token_hint].present? %>
+        <%= hidden_field_tag :acr_values, params[:acr_values], id: nil if params[:acr_values].present? %>
+        <%# Binds this consent to the account whose data is displayed above, so a
+            stale tab can't approve for a different account. %>
+        <%= hidden_field_tag :selected_account, consent_identity&.public_id, id: nil %>
         <%= submit_tag auth_label, "x-bind:disabled": "!ready", "x-bind:value": "ready ? authLabel : `Wait ${countdown}s...`", class: "approve" %>
       <% end %>
     </div>

--- a/app/views/public_activity/identity_session/_account_added.html.erb
+++ b/app/views/public_activity/identity_session/_account_added.html.erb
@@ -1,0 +1,15 @@
+<%#
+  Deliberately says nothing about the other accounts in the browser. This log is
+  visible to the account it belongs to, so naming a sibling identity would leak
+  the existence and address of a separate account.
+%>
+<%= render Components::PublicActivity::Snippet.new(activity, owner: activity.trackable&.identity) do %>
+  <%
+    session = activity.trackable
+    device_parts = []
+    device_parts << session&.device_info if session&.device_info.present?
+    device_parts << session&.os_info if session&.os_info.present?
+    device_str = device_parts.any? ? " on #{device_parts.join(", ")}" : ""
+  %>
+  was added to an existing browser session<%= device_str %>.
+<% end %>

--- a/app/views/public_activity/identity_session/_account_removed.html.erb
+++ b/app/views/public_activity/identity_session/_account_removed.html.erb
@@ -1,0 +1,4 @@
+<%# Never names the other accounts in the browser — see _account_added. %>
+<%= render Components::PublicActivity::Snippet.new(activity, owner: activity.trackable&.identity) do %>
+  was signed out of a browser session.
+<% end %>

--- a/app/views/public_activity/identity_session/_account_switched.html.erb
+++ b/app/views/public_activity/identity_session/_account_switched.html.erb
@@ -1,0 +1,4 @@
+<%# Never names the account switched away from — see _account_added. %>
+<%= render Components::PublicActivity::Snippet.new(activity, owner: activity.trackable&.identity) do %>
+  became the active account in this browser.
+<% end %>

--- a/app/views/saml/choose_account.html.erb
+++ b/app/views/saml/choose_account.html.erb
@@ -1,0 +1,26 @@
+<% content_for :title, t("accounts.saml_title", service: @sp_config[:friendly_name]) %>
+<div class="auth-container">
+  <div class="auth-brand">
+    <%= vite_image_tag "images/hc-square.png", alt: "Hack Club logo", class: "brand-logo" %>
+    <span class="brand-text"><%= t("brand") %></span>
+  </div>
+
+  <div class="auth-card">
+    <header>
+      <h1><%= t("accounts.saml_title", service: @sp_config[:friendly_name]) %></h1>
+      <small><%= t("accounts.saml_subtitle") %></small>
+    </header>
+
+    <%# Posts straight back to this endpoint: an IdP-initiated flow has no GET to
+        park and replay, so the choice travels with the resubmission. %>
+    <%= render "browser_accounts/account_list",
+          accounts: @accounts,
+          submit_url: idp_initiated_saml_path(slug: params[:slug]),
+          field_name: :selected_account,
+          preselect_public_id: @preselect_public_id %>
+
+    <p>
+      <small><%= t("accounts.saml_eligibility_note") %></small>
+    </p>
+  </div>
+</div>

--- a/app/views/saml/http_post.html.erb
+++ b/app/views/saml/http_post.html.erb
@@ -1,5 +1,6 @@
 <% content_for :title, t(".title") %>
-<% unless current_identity.saml_debug? %>
+<% saml_debug = (@saml_identity || current_identity)&.saml_debug? %>
+<% unless saml_debug %>
   <% content_for :head do %>
     <script type="text/javascript">
         document.addEventListener("DOMContentLoaded", () => {
@@ -16,7 +17,7 @@
   message = Base64.encode64(message.to_s) unless message.is_a?(String)
 %>
 
-<% if current_identity.saml_debug? %>
+<% if saml_debug %>
   we're about to assert to <code><%= target %></code> that...<br>
   <% if @saml_request %>
     SAMLRequest: <pre><%= pretty_xml(Base64.decode64(@saml_request)) rescue @saml_request %></pre> <br>

--- a/config/flipper_features.yml
+++ b/config/flipper_features.yml
@@ -1,4 +1,5 @@
 shared:
+  multi_account_sessions_2026_07_24: lets one browser hold several signed-in accounts, with a chooser on the OIDC and SAML sign-in screens
   persona_verification_2026_04_09: routes new users through Persona identity verification instead of document upload
   persona_verification_in_india_2026_06_05: gates Persona verification for users in India, pending Aadhaar support
   are_we_enterprise_yet_2025_10_21: enables Slack Enterprise Grid features (SAML, SCIM provisioning)

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -509,6 +509,10 @@ Doorkeeper.configure do
   # the same tool doesn't re-prompt. A convenience only — never consulted ahead
   # of prompt=select_account or an explicit hint.
   after_successful_authorization do |controller, _context|
+    # Also fires on the token endpoint, whose controller is a metal controller with
+    # no cookies and no session helpers. Nothing to remember there.
+    next unless controller.respond_to?(:current_browser_session, true)
+
     browser_session = controller.send(:current_browser_session)
     identity = Current.identity_session&.identity
     client_id = controller.params[:client_id]

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -19,7 +19,14 @@ Doorkeeper.configure do
 
   # This block will be called to check whether the resource owner is authenticated or not.
   resource_owner_authenticator do
-    if current_identity
+    # OidcAccountSelection resolves which of the browser's accounts this request
+    # is for; without it (or outside the authorize endpoint) fall back to the
+    # active account.
+    selected = respond_to?(:oidc_selected_identity, true) ? oidc_selected_identity : nil
+
+    if selected
+      selected
+    elsif current_identity
       current_identity
     else
       redirect_to "/oauth/welcome?return_to=#{CGI.escape(request.fullpath)}"
@@ -496,6 +503,21 @@ Doorkeeper.configure do
       )
     end
   rescue StandardError => e
+  end
+
+  # Remember which account this browser used for this client, so coming back to
+  # the same tool doesn't re-prompt. A convenience only — never consulted ahead
+  # of prompt=select_account or an explicit hint.
+  after_successful_authorization do |controller, _context|
+    browser_session = controller.send(:current_browser_session)
+    identity = Current.identity_session&.identity
+    client_id = controller.params[:client_id]
+
+    if browser_session && identity && client_id.present?
+      browser_session.remember_selection!(kind: "oidc", ref: client_id, identity: identity)
+    end
+  rescue StandardError => e
+    Rails.logger.warn("Failed to remember account selection: #{e.class}: #{e.message}")
   end
 
   # Under some circumstances you might want to have applications auto-approved,

--- a/config/initializers/doorkeeper_oidc_patches.rb
+++ b/config/initializers/doorkeeper_oidc_patches.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# These patches thread the current identity session through doorkeeper-openid_connect's
+# ID token generation, so auth_time reflects the actual session that authorized the
+# request — not just the most recently created session for the identity.
+#
+# The flow:
+#   1. Authorization endpoint (user in browser): Current.identity_session is set by
+#      ApplicationController. The grant is stamped with source_session_id.
+#   2. Token endpoint (RP server exchanging auth code): No user session cookie, but
+#      we load the source session from the grant and set it directly on the IdToken.
+#   3. IdToken checks @source_session (from grant) then Current.identity_session
+#      (from cookie). Returns nil if neither is available — we don't guess.
+
+Rails.application.config.to_prepare do
+  # Stamp source_session_id on the grant at authorization time
+  Doorkeeper::OAuth::Authorization::Code.prepend(Module.new do
+    private
+
+    def access_grant_attributes
+      super.merge(source_session_id: Current.identity_session&.id)
+    end
+  end)
+
+  # At code exchange, set the source session directly on the IdToken from the grant.
+  # We call super first (openid_connect creates the IdToken), then attach the session.
+  # Current.identity_session stays honest — it only means "the session behind this request."
+  Doorkeeper::OAuth::AuthorizationCodeRequest.prepend(Module.new do
+    private
+
+    def after_successful_response
+      super
+      if grant.source_session_id && @response.id_token
+        session = IdentitySession.find_by(id: grant.source_session_id)
+        @response.id_token.instance_variable_set(:@source_session, session)
+      end
+    end
+  end)
+
+  # Use the real session for auth_time: @source_session (from grant, set during code
+  # exchange) or Current.identity_session (from cookie, set during controller flows).
+  # Returns nil if neither is available — don't guess, don't lie.
+  Doorkeeper::OpenidConnect::IdToken.prepend(Module.new do
+    private
+
+    def auth_time
+      session = @source_session || Current.identity_session
+      return nil unless session
+
+      [ session.created_at, session.last_step_up_at ].compact.max.to_i
+    end
+  end)
+end

--- a/config/initializers/doorkeeper_oidc_patches.rb
+++ b/config/initializers/doorkeeper_oidc_patches.rb
@@ -75,6 +75,11 @@ Rails.application.config.to_prepare do
     def provider_response
       response = super
 
+      # acr_values_supported lists the values we may *return*. A requested
+      # `acr_values` is treated as voluntary (OIDC Core 3.1.2.1): we report the
+      # assurance the session actually has rather than forcing a step-up the user
+      # may have no second factor to satisfy. An RP that needs a guarantee has to
+      # ask for it as an essential claim, which we do not support yet.
       response.merge(
         prompt_values_supported: %w[none login consent select_account],
         acr_values_supported: [

--- a/config/initializers/doorkeeper_oidc_patches.rb
+++ b/config/initializers/doorkeeper_oidc_patches.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 # These patches thread the current identity session through doorkeeper-openid_connect's
-# ID token generation, so auth_time reflects the actual session that authorized the
-# request — not just the most recently created session for the identity.
+# ID token generation, so auth_time, amr and acr reflect the actual session that
+# authorized the request — not just the most recently created session for the identity.
 #
 # The flow:
 #   1. Authorization endpoint (user in browser): Current.identity_session is set by
@@ -11,6 +11,9 @@
 #      we load the source session from the grant and set it directly on the IdToken.
 #   3. IdToken checks @source_session (from grant) then Current.identity_session
 #      (from cookie). Returns nil if neither is available — we don't guess.
+#
+# Once a browser can hold several accounts, "the session behind this request" is the
+# selected account's session, so assurance claims can never leak across accounts.
 
 Rails.application.config.to_prepare do
   # Stamp source_session_id on the grant at authorization time
@@ -37,17 +40,49 @@ Rails.application.config.to_prepare do
     end
   end)
 
-  # Use the real session for auth_time: @source_session (from grant, set during code
-  # exchange) or Current.identity_session (from cookie, set during controller flows).
-  # Returns nil if neither is available — don't guess, don't lie.
+  # auth_time, amr and acr all come from one session so they can never disagree.
+  # nil values are dropped by IdToken#as_json, so an unknown assurance level is
+  # simply absent rather than guessed.
   Doorkeeper::OpenidConnect::IdToken.prepend(Module.new do
+    def claims
+      super.merge(amr: amr, acr: acr)
+    end
+
     private
 
+    # @source_session comes from the grant during code exchange;
+    # Current.identity_session from the cookie during controller flows.
+    def oidc_identity_session
+      @source_session || Current.identity_session
+    end
+
     def auth_time
-      session = @source_session || Current.identity_session
+      session = oidc_identity_session
       return nil unless session
 
       [ session.created_at, session.last_step_up_at ].compact.max.to_i
+    end
+
+    def amr = oidc_identity_session&.amr_values
+
+    def acr = oidc_identity_session&.acr_value
+  end)
+
+  # The gem's discovery document doesn't advertise prompt or acr support.
+  Doorkeeper::OpenidConnect::DiscoveryController.prepend(Module.new do
+    private
+
+    def provider_response
+      response = super
+
+      response.merge(
+        prompt_values_supported: %w[none login consent select_account],
+        acr_values_supported: [
+          IdentitySession::ACR_SINGLE_FACTOR,
+          IdentitySession::ACR_MULTI_FACTOR
+        ],
+        claims_supported: (response[:claims_supported] || []) | %w[auth_time amr acr]
+      )
     end
   end)
 end

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -26,15 +26,15 @@ Doorkeeper::OpenidConnect.configure do
   end
 
   auth_time_from_resource_owner do |resource_owner|
-    session = resource_owner.sessions.not_expired.order(created_at: :desc).first
-    return nil unless session
+    session = Current.identity_session
+    next nil unless session
 
     [ session.created_at, session.last_step_up_at ].compact.max
   end
 
   reauthenticate_resource_owner do |resource_owner, return_to|
-    session = resource_owner.sessions.not_expired.order(created_at: :desc).first
-    return if session&.last_step_up_at&.after?(60.seconds.ago)
+    session = Current.identity_session
+    next if session&.last_step_up_at&.after?(60.seconds.ago)
 
     redirect_to new_step_up_path(action_type: "oidc_reauth", return_to: return_to)
   end

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -39,6 +39,19 @@ Doorkeeper::OpenidConnect.configure do
     redirect_to new_step_up_path(action_type: "oidc_reauth", return_to: return_to)
   end
 
+  # The gem's default for this hook raises, which is why prompt=select_account
+  # used to be a hard error. OidcAccountSelection has already decided by the time
+  # we get here, so this only has to handle the case where it chose to proceed
+  # (single account, or the chooser is off) — in which case there is nothing to
+  # ask about.
+  select_account_for_resource_owner do |_resource_owner, return_to|
+    if respond_to?(:current_browser_session, true) &&
+        current_browser_session&.account_count.to_i > 1 &&
+        Flipper.enabled?(BrowserAccountsController::FEATURE_FLAG, current_identity)
+      redirect_to browser_accounts_path(return_to: return_to)
+    end
+  end
+
   subject { |ident, _application| ident.public_id }
 
   claims do

--- a/config/initializers/doorkeeper_openid_connect.rb
+++ b/config/initializers/doorkeeper_openid_connect.rb
@@ -40,16 +40,17 @@ Doorkeeper::OpenidConnect.configure do
   end
 
   # The gem's default for this hook raises, which is why prompt=select_account
-  # used to be a hard error. OidcAccountSelection has already decided by the time
-  # we get here, so this only has to handle the case where it chose to proceed
-  # (single account, or the chooser is off) — in which case there is nothing to
-  # ask about.
-  select_account_for_resource_owner do |_resource_owner, return_to|
-    if respond_to?(:current_browser_session, true) &&
-        current_browser_session&.account_count.to_i > 1 &&
-        Flipper.enabled?(BrowserAccountsController::FEATURE_FLAG, current_identity)
-      redirect_to browser_accounts_path(return_to: return_to)
-    end
+  # used to be a hard error. OidcAccountSelection has normally decided long before
+  # we get here; this is the backstop for anything it didn't resolve. It parks the
+  # request the same way the concern does, because /accounts speaks pending
+  # handles, not return_to — a return_to would be silently dropped and the
+  # authorization request lost.
+  select_account_for_resource_owner do |_resource_owner, _return_to|
+    next unless respond_to?(:park_oidc_request_and_choose, true)
+    next unless account_chooser_available?
+    next unless current_browser_session&.account_count.to_i > 1
+
+    park_oidc_request_and_choose
   end
 
   subject { |ident, _application| ident.public_id }

--- a/config/initializers/monkey_patches.rb
+++ b/config/initializers/monkey_patches.rb
@@ -11,6 +11,7 @@ Rails.application.config.to_prepare do
 
   class Doorkeeper::AuthorizationsController
     include AhoyAnalytics
+    include OidcAccountSelection
 
     layout "logged_out"
     after_action :track_oauth_denied, only: :destroy

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -35,6 +35,12 @@ class Rack::Attack
     end
   end
 
+  throttle("account_switch/ip", limit: 20, period: 5.minutes) do |req|
+    if req.post? && req.path.start_with?("/accounts/")
+      req.ip
+    end
+  end
+
   throttle("email_change/ip", limit: 3, period: 1.hour) do |req|
     if req.path == "/email_changes" && req.post?
       req.ip

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -35,7 +35,11 @@ class Rack::Attack
     end
   end
 
-  throttle("account_switch/ip", limit: 20, period: 5.minutes) do |req|
+  # Deliberately loose for an IP bucket: switching is bounded by what is already
+  # signed into the browser (BrowserSession::MAX_ACCOUNTS), and our users share
+  # school NATs, so a tight per-IP limit punishes a whole building for one busy
+  # tab. The browser session cookie can't be the key — it rotates on every switch.
+  throttle("account_switch/ip", limit: 60, period: 5.minutes) do |req|
     if req.post? && req.path.start_with?("/accounts/")
       req.ip
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -119,6 +119,25 @@ en:
       backend_user:
         slack_id: Slack ID
   brand: Hack Club Auth
+  accounts:
+    title: Choose an account
+    subtitle: Pick which Hack Club account to continue with.
+    signing_in_as: Signing in as
+    switch: Switch account
+    use_another: Use another account
+    sign_out_all: Sign out of all accounts
+    remove: Sign out
+    remove_confirm: "Sign out of %{email} in this browser?"
+    active: Active
+    single_factor: No 2FA
+    last_used: "Used %{when} ago"
+    limit_reached: "You can be signed into %{max} accounts in one browser. Sign one out to add another."
+    saml_title: "Continue to %{service}"
+    saml_subtitle: Pick which Hack Club account to sign in with.
+    saml_eligibility_note: Only accounts this service accepts are listed.
+    kind:
+      hack_club: Hack Club
+      personal: Personal
   home:
     apps:
       heading: Where do you want to go today?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,7 @@ en:
     single_factor: No 2FA
     last_used: "Used %{when} ago"
     limit_reached: "You can be signed into %{max} accounts in one browser. Sign one out to add another."
+    limit_error: "You're signed into the maximum number of accounts in this browser (%{max}). Sign one out first."
     saml_title: "Continue to %{service}"
     saml_subtitle: Pick which Hack Club account to sign in with.
     saml_eligibility_note: Only accounts this service accepts are listed.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,7 +162,9 @@ class SuperAdminConstraint
     session_token = request.cookie_jar.encrypted[:session_token]
     return false unless session_token
 
-    session = IdentitySession.not_expired.find_by(session_token: session_token)
+    # Read-only: the cookie now names a BrowserSession, and a routing constraint
+    # is no place to adopt legacy sessions.
+    session = SessionResolver.identity_session(session_token)
     return false unless session&.identity
 
     session.identity.backend_user&.super_admin?
@@ -318,6 +320,15 @@ Rails.application.routes.draw do
   post "/login/:id/webauthn/skip", to: "logins#skip_webauthn", as: :skip_webauthn_login_attempt
 
   delete "/logout", to: "sessions#logout", as: :logout
+  delete "/logout/all", to: "sessions#logout_all", as: :logout_all
+
+  # Accounts signed into this browser. The chooser, plus switching, adding and
+  # removing accounts.
+  get "/accounts", to: "browser_accounts#index", as: :browser_accounts
+  post "/accounts/switch", to: "browser_accounts#switch", as: :switch_browser_account
+  post "/accounts/add", to: "browser_accounts#add", as: :add_browser_account
+  delete "/accounts/:id", to: "browser_accounts#destroy", as: :browser_account
+  get "/accounts/resume", to: "browser_accounts#resume", as: :resume_browser_account
 
   get "/verifications/new", to: "verifications#new", as: :new_verifications
   get "/verifications/status", to: "verifications#status", as: :verification_status

--- a/db/migrate/20260725000001_create_browser_sessions.rb
+++ b/db/migrate/20260725000001_create_browser_sessions.rb
@@ -1,0 +1,20 @@
+class CreateBrowserSessions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :browser_sessions do |t|
+      t.string :token_bidx
+      t.text :token_ciphertext
+      t.bigint :active_identity_session_id
+      t.datetime :expires_at, null: false
+      t.datetime :last_seen
+
+      t.timestamps
+    end
+
+    add_index :browser_sessions, :token_bidx, unique: true
+    add_index :browser_sessions, :expires_at
+    add_index :browser_sessions, :active_identity_session_id
+
+    add_foreign_key :browser_sessions, :identity_sessions,
+      column: :active_identity_session_id, on_delete: :nullify
+  end
+end

--- a/db/migrate/20260725000002_add_browser_session_to_identity_sessions.rb
+++ b/db/migrate/20260725000002_add_browser_session_to_identity_sessions.rb
@@ -1,0 +1,12 @@
+class AddBrowserSessionToIdentitySessions < ActiveRecord::Migration[8.0]
+  def change
+    # Nullable on purpose: existing sessions are adopted lazily on their next
+    # request (SessionsHelper#current_browser_session) so nobody gets logged out.
+    add_column :identity_sessions, :browser_session_id, :bigint
+    add_column :identity_sessions, :revoked_reason, :string
+
+    add_index :identity_sessions, :browser_session_id
+    add_foreign_key :identity_sessions, :browser_sessions,
+      column: :browser_session_id, on_delete: :nullify
+  end
+end

--- a/db/migrate/20260725000003_add_missing_indexes_to_identity_sessions.rb
+++ b/db/migrate/20260725000003_add_missing_indexes_to_identity_sessions.rb
@@ -1,0 +1,11 @@
+class AddMissingIndexesToIdentitySessions < ActiveRecord::Migration[8.0]
+  disable_ddl_transaction!
+
+  # session_token_bidx is looked up on every authenticated request and has never
+  # been indexed. expires_at is in every scope. Concurrent so this doesn't lock
+  # the table on deploy.
+  def change
+    add_index :identity_sessions, :session_token_bidx, algorithm: :concurrently
+    add_index :identity_sessions, :expires_at, algorithm: :concurrently
+  end
+end

--- a/db/migrate/20260725000003_add_missing_indexes_to_identity_sessions.rb
+++ b/db/migrate/20260725000003_add_missing_indexes_to_identity_sessions.rb
@@ -4,8 +4,10 @@ class AddMissingIndexesToIdentitySessions < ActiveRecord::Migration[8.0]
   # session_token_bidx is looked up on every authenticated request and has never
   # been indexed. expires_at is in every scope. Concurrent so this doesn't lock
   # the table on deploy.
+  # if_not_exists because a concurrent build that fails leaves an INVALID index
+  # behind, and the retry would then collide with it.
   def change
-    add_index :identity_sessions, :session_token_bidx, algorithm: :concurrently
-    add_index :identity_sessions, :expires_at, algorithm: :concurrently
+    add_index :identity_sessions, :session_token_bidx, algorithm: :concurrently, if_not_exists: true
+    add_index :identity_sessions, :expires_at, algorithm: :concurrently, if_not_exists: true
   end
 end

--- a/db/migrate/20260725000004_create_browser_session_client_selections.rb
+++ b/db/migrate/20260725000004_create_browser_session_client_selections.rb
@@ -1,0 +1,24 @@
+class CreateBrowserSessionClientSelections < ActiveRecord::Migration[8.0]
+  def change
+    create_table :browser_session_client_selections do |t|
+      t.bigint :browser_session_id, null: false
+      t.string :client_kind, null: false
+      t.string :client_ref, null: false
+      # Points at the identity rather than the session so stickiness survives
+      # that account's session expiring.
+      t.bigint :identity_id, null: false
+      t.datetime :last_used_at
+
+      t.timestamps
+    end
+
+    add_index :browser_session_client_selections,
+      [ :browser_session_id, :client_kind, :client_ref ],
+      unique: true,
+      name: "index_client_selections_on_browser_session_and_client"
+    add_index :browser_session_client_selections, :identity_id
+
+    add_foreign_key :browser_session_client_selections, :browser_sessions, on_delete: :cascade
+    add_foreign_key :browser_session_client_selections, :identities, on_delete: :cascade
+  end
+end

--- a/db/migrate/20260725000005_create_pending_authorizations.rb
+++ b/db/migrate/20260725000005_create_pending_authorizations.rb
@@ -1,0 +1,23 @@
+class CreatePendingAuthorizations < ActiveRecord::Migration[8.0]
+  def change
+    create_table :pending_authorizations do |t|
+      # The anti-swap binding: a handle may only be resumed by the browser
+      # session that created it.
+      t.bigint :browser_session_id, null: false
+      t.string :token_bidx
+      t.text :token_ciphertext
+      t.string :kind, null: false
+      t.text :payload_ciphertext
+      t.datetime :expires_at, null: false
+      t.datetime :consumed_at
+
+      t.timestamps
+    end
+
+    add_index :pending_authorizations, :token_bidx, unique: true
+    add_index :pending_authorizations, :browser_session_id
+    add_index :pending_authorizations, :expires_at
+
+    add_foreign_key :pending_authorizations, :browser_sessions, on_delete: :cascade
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_06_22_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_25_000005) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -132,6 +132,31 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_22_000001) do
     t.index ["backend_user_id"], name: "index_break_glass_records_on_backend_user_id"
     t.index ["break_glassable_id", "break_glassable_type"], name: "idx_on_break_glassable_id_break_glassable_type_14e1e3ce71"
     t.index ["break_glassable_id"], name: "index_break_glass_records_on_break_glassable_id"
+  end
+
+  create_table "browser_session_client_selections", force: :cascade do |t|
+    t.bigint "browser_session_id", null: false
+    t.string "client_kind", null: false
+    t.string "client_ref", null: false
+    t.bigint "identity_id", null: false
+    t.datetime "last_used_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["browser_session_id", "client_kind", "client_ref"], name: "index_client_selections_on_browser_session_and_client", unique: true
+    t.index ["identity_id"], name: "index_browser_session_client_selections_on_identity_id"
+  end
+
+  create_table "browser_sessions", force: :cascade do |t|
+    t.string "token_bidx"
+    t.text "token_ciphertext"
+    t.bigint "active_identity_session_id"
+    t.datetime "expires_at", null: false
+    t.datetime "last_seen"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_identity_session_id"], name: "index_browser_sessions_on_active_identity_session_id"
+    t.index ["expires_at"], name: "index_browser_sessions_on_expires_at"
+    t.index ["token_bidx"], name: "index_browser_sessions_on_token_bidx", unique: true
   end
 
   create_table "console1984_commands", force: :cascade do |t|
@@ -449,7 +474,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_22_000001) do
     t.datetime "updated_at", null: false
     t.datetime "last_step_up_at"
     t.string "last_step_up_action"
+    t.bigint "browser_session_id"
+    t.string "revoked_reason"
+    t.index ["browser_session_id"], name: "index_identity_sessions_on_browser_session_id"
+    t.index ["expires_at"], name: "index_identity_sessions_on_expires_at"
     t.index ["identity_id"], name: "index_identity_sessions_on_identity_id"
+    t.index ["session_token_bidx"], name: "index_identity_sessions_on_session_token_bidx"
   end
 
   create_table "identity_tombstone_collisions", force: :cascade do |t|
@@ -580,6 +610,21 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_22_000001) do
     t.index ["access_grant_id"], name: "index_oauth_openid_requests_on_access_grant_id"
   end
 
+  create_table "pending_authorizations", force: :cascade do |t|
+    t.bigint "browser_session_id", null: false
+    t.string "token_bidx"
+    t.text "token_ciphertext"
+    t.string "kind", null: false
+    t.text "payload_ciphertext"
+    t.datetime "expires_at", null: false
+    t.datetime "consumed_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["browser_session_id"], name: "index_pending_authorizations_on_browser_session_id"
+    t.index ["expires_at"], name: "index_pending_authorizations_on_expires_at"
+    t.index ["token_bidx"], name: "index_pending_authorizations_on_token_bidx", unique: true
+  end
+
   create_table "program_collaborators", force: :cascade do |t|
     t.bigint "program_id", null: false
     t.bigint "identity_id"
@@ -667,6 +712,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_22_000001) do
   add_foreign_key "backend_organizer_positions", "oauth_applications", column: "program_id"
   add_foreign_key "backend_users", "identities"
   add_foreign_key "break_glass_records", "backend_users"
+  add_foreign_key "browser_session_client_selections", "browser_sessions", on_delete: :cascade
+  add_foreign_key "browser_session_client_selections", "identities", on_delete: :cascade
+  add_foreign_key "browser_sessions", "identity_sessions", column: "active_identity_session_id", on_delete: :nullify
   add_foreign_key "identities", "addresses", column: "primary_address_id"
   add_foreign_key "identity_aadhaar_records", "identities"
   add_foreign_key "identity_backup_codes", "identities"
@@ -678,6 +726,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_22_000001) do
   add_foreign_key "identity_resemblances", "identities", column: "past_identity_id"
   add_foreign_key "identity_resemblances", "identity_documents", column: "document_id"
   add_foreign_key "identity_resemblances", "identity_documents", column: "past_document_id"
+  add_foreign_key "identity_sessions", "browser_sessions", on_delete: :nullify
   add_foreign_key "identity_sessions", "identities"
   add_foreign_key "identity_tombstone_collisions", "deletions"
   add_foreign_key "identity_tombstone_collisions", "identities"
@@ -693,6 +742,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_06_22_000001) do
   add_foreign_key "oauth_access_tokens", "identities", column: "resource_owner_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_openid_requests", "oauth_access_grants", column: "access_grant_id", on_delete: :cascade
+  add_foreign_key "pending_authorizations", "browser_sessions", on_delete: :cascade
   add_foreign_key "program_collaborators", "identities"
   add_foreign_key "program_collaborators", "oauth_applications", column: "program_id"
   add_foreign_key "verifications", "identities"

--- a/spec/controllers/concerns/saml_account_selection_spec.rb
+++ b/spec/controllers/concerns/saml_account_selection_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe SAMLAccountSelection, type: :controller do
+  controller(ApplicationController) do
+    include SAMLAccountSelection
+    skip_before_action :authenticate_identity!
+
+    def replay_url
+      render plain: saml_replay_url
+    end
+  end
+
+  before do
+    routes.draw { get "replay_url" => "anonymous#replay_url" }
+  end
+
+  it "removes the one-shot chooser trigger from a parked SAML URL" do
+    get :replay_url, params: {
+      SAMLRequest: "request",
+      RelayState: "state",
+      select_account: "1"
+    }
+
+    query = Rack::Utils.parse_query(URI.parse(response.body).query)
+    expect(query).to include("SAMLRequest" => "request", "RelayState" => "state")
+    expect(query).not_to have_key("select_account")
+  end
+end

--- a/spec/factories/browser_sessions.rb
+++ b/spec/factories/browser_sessions.rb
@@ -1,0 +1,23 @@
+FactoryBot.define do
+  factory :browser_session do
+    token { SecureRandom.urlsafe_base64 }
+    expires_at { 1.month.from_now }
+
+    trait :expired do
+      expires_at { 1.hour.ago }
+    end
+
+    # Builds a browser session holding one signed-in account.
+    transient do
+      identity { nil }
+    end
+
+    trait :with_account do
+      after(:create) do |browser_session, evaluator|
+        identity = evaluator.identity || create(:identity)
+        ident_session = create(:identity_session, identity: identity, browser_session: browser_session)
+        browser_session.activate!(ident_session)
+      end
+    end
+  end
+end

--- a/spec/factories/identity_sessions.rb
+++ b/spec/factories/identity_sessions.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :identity_session do
+    association :identity
+    session_token { SecureRandom.urlsafe_base64 }
+    expires_at { 1.month.from_now }
+
+    trait :expired do
+      expires_at { 1.hour.ago }
+    end
+
+    trait :stepped_up do
+      last_step_up_at { Time.current }
+      last_step_up_action { "oidc_reauth" }
+    end
+  end
+end

--- a/spec/factories/pending_authorizations.rb
+++ b/spec/factories/pending_authorizations.rb
@@ -1,0 +1,22 @@
+FactoryBot.define do
+  factory :pending_authorization do
+    association :browser_session
+    token { SecureRandom.urlsafe_base64 }
+    kind { "oidc" }
+    payload { { "params" => { "client_id" => "abc", "redirect_uri" => "https://example.com/callback" } } }
+    expires_at { PendingAuthorization::EXPIRATION.from_now }
+
+    trait :expired do
+      expires_at { 1.minute.ago }
+    end
+
+    trait :consumed do
+      consumed_at { Time.current }
+    end
+
+    trait :saml do
+      kind { "saml" }
+      payload { { "url" => "/saml/auth?SAMLRequest=abc", "entity_id" => "https://sp.example.com" } }
+    end
+  end
+end

--- a/spec/models/browser_session_spec.rb
+++ b/spec/models/browser_session_spec.rb
@@ -1,0 +1,123 @@
+require "rails_helper"
+
+RSpec.describe BrowserSession, type: :model do
+  let(:browser_session) { create(:browser_session) }
+  let(:identity) { create(:identity) }
+
+  def add_account(session, account_identity = create(:identity))
+    ident_session = create(:identity_session, identity: account_identity, browser_session: session)
+    session.activate!(ident_session)
+    ident_session
+  end
+
+  describe "account membership" do
+    it "lists live accounts oldest first" do
+      first = add_account(browser_session)
+      second = add_account(browser_session)
+
+      expect(browser_session.live_identity_sessions.to_a).to eq([ first, second ])
+    end
+
+    it "excludes expired and signed-out accounts" do
+      live = add_account(browser_session)
+      expired = create(:identity_session, :expired, browser_session: browser_session)
+      signed_out = add_account(browser_session)
+      signed_out.revoke!(reason: "user_signout")
+
+      expect(browser_session.live_identity_sessions).to contain_exactly(live)
+      expect(browser_session.live_identity_sessions).not_to include(expired)
+    end
+
+    it "caps the number of accounts" do
+      described_class::MAX_ACCOUNTS.times { add_account(browser_session) }
+
+      expect(browser_session).to be_at_account_limit
+    end
+
+    it "refuses to activate a session belonging to another browser session" do
+      other = add_account(create(:browser_session))
+
+      expect { browser_session.activate!(other) }.to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#active_session" do
+    it "returns nil rather than promoting a sibling when the active account expires" do
+      active = add_account(browser_session)
+      sibling = add_account(browser_session)
+      browser_session.activate!(active)
+
+      active.update!(expires_at: 1.minute.ago)
+
+      expect(browser_session.reload.active_session).to be_nil
+      expect(browser_session.live_identity_sessions).to include(sibling)
+    end
+
+    it "returns nil for a signed-out active account" do
+      active = add_account(browser_session)
+      active.revoke!(reason: "user_signout")
+
+      expect(browser_session.reload.active_session).to be_nil
+    end
+  end
+
+  describe "expiry independence" do
+    it "does not extend a sibling's expiry when another account is added" do
+      first = add_account(browser_session)
+      original_expiry = first.expires_at
+
+      travel_to(2.days.from_now) do
+        add_account(browser_session)
+        expect(first.reload.expires_at).to be_within(1.second).of(original_expiry)
+      end
+    end
+
+    it "only extends the browser session forwards" do
+      browser_session.update!(expires_at: 10.days.from_now)
+
+      browser_session.extend_expiry!(1.day.from_now)
+      expect(browser_session.expires_at).to be_within(1.minute).of(10.days.from_now)
+
+      browser_session.extend_expiry!(30.days.from_now)
+      expect(browser_session.expires_at).to be_within(1.minute).of(30.days.from_now)
+    end
+  end
+
+  describe "#rotate_token!" do
+    it "changes the token without disturbing the accounts" do
+      account = add_account(browser_session)
+      before = browser_session.token
+
+      browser_session.rotate_token!
+
+      expect(browser_session.token).not_to eq(before)
+      expect(browser_session.reload.live_identity_sessions).to include(account)
+      expect(browser_session.active_identity_session_id).to eq(account.id)
+    end
+  end
+
+  describe "sticky selections" do
+    it "remembers and returns the session for a client" do
+      account = add_account(browser_session, identity)
+
+      browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: identity)
+
+      expect(browser_session.remembered_identity_session(kind: "oidc", ref: "client-abc")).to eq(account)
+    end
+
+    it "treats a remembered account with no live session as absent" do
+      account = add_account(browser_session, identity)
+      browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: identity)
+      account.revoke!(reason: "user_signout")
+
+      expect(browser_session.remembered_identity_session(kind: "oidc", ref: "client-abc")).to be_nil
+    end
+
+    it "keys selections separately per client and kind" do
+      add_account(browser_session, identity)
+      browser_session.remember_selection!(kind: "oidc", ref: "same-ref", identity: identity)
+
+      expect(browser_session.remembered_identity_session(kind: "saml", ref: "same-ref")).to be_nil
+    end
+  end
+end

--- a/spec/models/browser_session_spec.rb
+++ b/spec/models/browser_session_spec.rb
@@ -119,5 +119,81 @@ RSpec.describe BrowserSession, type: :model do
 
       expect(browser_session.remembered_identity_session(kind: "saml", ref: "same-ref")).to be_nil
     end
+
+    # Two tabs authorizing the same client race the unique index. The upsert has
+    # to move the pointer in place: a second row is impossible, and an exception
+    # here would poison whatever transaction we were called from.
+    it "moves an existing selection instead of inserting a second row" do
+      first = add_account(browser_session, identity)
+      other_identity = create(:identity)
+      second = add_account(browser_session, other_identity)
+
+      browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: identity)
+      created_at = browser_session.client_selections.sole.created_at
+
+      browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: other_identity)
+
+      selection = browser_session.client_selections.reload.sole
+      expect(selection.identity_id).to eq(other_identity.id)
+      expect(selection.created_at).to be_within(1.second).of(created_at)
+      expect(browser_session.remembered_identity_session(kind: "oidc", ref: "client-abc")).to eq(second)
+      expect(first.reload).to be_live
+    end
+
+    it "keeps working when called from inside a transaction" do
+      add_account(browser_session, identity)
+
+      expect do
+        ActiveRecord::Base.transaction do
+          browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: identity)
+          browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: identity)
+        end
+      end.not_to raise_error
+
+      expect(browser_session.client_selections.reload.count).to eq(1)
+    end
+
+    it "refuses a client kind it doesn't know" do
+      add_account(browser_session, identity)
+
+      expect { browser_session.remember_selection!(kind: "ldap", ref: "x", identity: identity) }
+        .to raise_error(ArgumentError)
+    end
+  end
+
+  describe "#touch_last_seen_at" do
+    it "records activity, then holds off until the cooldown passes" do
+      expect(browser_session.last_seen).to be_nil
+
+      browser_session.touch_last_seen_at
+      first_seen = browser_session.reload.last_seen
+      expect(first_seen).to be_present
+
+      browser_session.touch_last_seen_at
+      expect(browser_session.reload.last_seen).to be_within(1.second).of(first_seen)
+
+      travel_to(described_class::LAST_SEEN_AT_COOLDOWN.from_now + 1.minute) do
+        browser_session.touch_last_seen_at
+        expect(browser_session.reload.last_seen).to be > first_seen
+      end
+    end
+  end
+
+  describe "audit trail" do
+    it "never versions the token, its ciphertext, or its blind index" do
+      browser_session.rotate_token!
+
+      versioned = PaperTrail::Version
+        .where(item_type: "BrowserSession", item_id: browser_session.id)
+        .flat_map { |version| (version.object_changes || {}).keys }
+
+      expect(versioned).not_to include("token", "token_ciphertext", "token_bidx")
+    end
+  end
+
+  describe "validations" do
+    it "refuses a browser session with no token" do
+      expect(described_class.new(expires_at: 1.day.from_now)).not_to be_valid
+    end
   end
 end

--- a/spec/models/identity_session_assurance_spec.rb
+++ b/spec/models/identity_session_assurance_spec.rb
@@ -1,0 +1,63 @@
+require "rails_helper"
+
+RSpec.describe IdentitySession, type: :model do
+  let(:identity) { create(:identity) }
+  let(:ident_session) { create(:identity_session, identity: identity) }
+
+  def record_factors(factors)
+    LoginAttempt.create!(
+      identity: identity,
+      session: ident_session,
+      authentication_factors: factors,
+      aasm_state: "complete",
+      provenance: "login",
+      next_action: "home"
+    )
+    ident_session.reload
+  end
+
+  describe "#amr_values" do
+    it "is nil when there is no login attempt to derive from" do
+      expect(ident_session.amr_values).to be_nil
+      expect(ident_session.acr_value).to be_nil
+    end
+
+    it "reports a single factor without mfa" do
+      record_factors("email" => true)
+
+      expect(ident_session.amr_values).to eq([ "otp" ])
+      expect(ident_session.acr_value).to eq(described_class::ACR_SINGLE_FACTOR)
+    end
+
+    it "adds mfa once two factors are satisfied" do
+      record_factors("email" => true, "totp" => true)
+
+      expect(ident_session.amr_values).to include("mfa")
+      expect(ident_session.acr_value).to eq(described_class::ACR_MULTI_FACTOR)
+    end
+
+    it "maps passkeys to hwk" do
+      record_factors("webauthn" => true)
+
+      expect(ident_session.amr_values).to eq([ "hwk" ])
+    end
+
+    it "ignores factors recorded as false" do
+      record_factors("email" => true, "totp" => false)
+
+      expect(ident_session.amr_values).to eq([ "otp" ])
+      expect(ident_session).not_to be_multi_factor
+    end
+  end
+
+  describe "#revoke!" do
+    it "expires the session and records why" do
+      ident_session.revoke!(reason: "user_signout")
+
+      expect(ident_session).to be_expired
+      expect(ident_session.signed_out_at).to be_present
+      expect(ident_session.revoked_reason).to eq("user_signout")
+      expect(ident_session).not_to be_live
+    end
+  end
+end

--- a/spec/models/pending_authorization_spec.rb
+++ b/spec/models/pending_authorization_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+
+RSpec.describe PendingAuthorization, type: :model do
+  let(:browser_session) { create(:browser_session) }
+
+  describe ".park!" do
+    it "stores the request encrypted, behind an opaque handle" do
+      pending = described_class.park!(
+        browser_session: browser_session,
+        kind: "oidc",
+        payload: { "params" => { "login_hint" => "nora@hackclub.com" } }
+      )
+
+      raw = ActiveRecord::Base.connection.select_value(
+        "SELECT payload_ciphertext FROM pending_authorizations WHERE id = #{pending.id}"
+      )
+      expect(raw).not_to include("nora@hackclub.com")
+      expect(pending.reload.payload.dig("params", "login_hint")).to eq("nora@hackclub.com")
+      expect(pending.token).to be_present
+    end
+  end
+
+  describe ".consume!" do
+    let!(:pending) { described_class.park!(browser_session: browser_session, kind: "oidc", payload: { "params" => {} }) }
+
+    it "returns the record and marks it used" do
+      consumed = described_class.consume!(token: pending.token, browser_session: browser_session)
+
+      expect(consumed).to eq(pending)
+      expect(pending.reload).to be_consumed
+    end
+
+    it "refuses a second use" do
+      described_class.consume!(token: pending.token, browser_session: browser_session)
+
+      expect(described_class.consume!(token: pending.token, browser_session: browser_session)).to be_nil
+    end
+
+    it "refuses a different browser session" do
+      other = create(:browser_session)
+
+      expect(described_class.consume!(token: pending.token, browser_session: other)).to be_nil
+      expect(pending.reload).not_to be_consumed
+    end
+
+    it "refuses an expired handle" do
+      pending.update!(expires_at: 1.minute.ago)
+
+      expect(described_class.consume!(token: pending.token, browser_session: browser_session)).to be_nil
+    end
+
+    it "refuses a kind mismatch" do
+      expect(described_class.consume!(token: pending.token, browser_session: browser_session, kind: "saml")).to be_nil
+    end
+
+    it "refuses a blank or unknown token" do
+      expect(described_class.consume!(token: nil, browser_session: browser_session)).to be_nil
+      expect(described_class.consume!(token: "nope", browser_session: browser_session)).to be_nil
+    end
+  end
+end

--- a/spec/models/pending_authorization_spec.rb
+++ b/spec/models/pending_authorization_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe PendingAuthorization, type: :model do
     end
   end
 
+  describe "reaping" do
+    it "clears this browser session's dead handles when parking a new one" do
+      dead = described_class.park!(browser_session: browser_session, kind: "oidc", payload: {})
+      dead.update!(expires_at: 1.minute.ago)
+      someone_elses = described_class.park!(browser_session: create(:browser_session), kind: "oidc", payload: {})
+      someone_elses.update!(expires_at: 1.minute.ago)
+
+      described_class.park!(browser_session: browser_session, kind: "oidc", payload: {})
+
+      expect(described_class.exists?(dead.id)).to be false
+      expect(described_class.exists?(someone_elses.id)).to be true
+      expect(browser_session.pending_authorizations.reload.count).to eq(1)
+    end
+  end
+
   describe ".consume!" do
     let!(:pending) { described_class.park!(browser_session: browser_session, kind: "oidc", payload: { "params" => {} }) }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -32,9 +32,13 @@ begin
 rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
+require_relative "support/authentication_helpers"
+
 RSpec.configure do |config|
   # FactoryBot configuration
   config.include FactoryBot::Syntax::Methods
+  config.include AuthenticationHelpers, type: :request
+  config.include ActiveSupport::Testing::TimeHelpers
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
   config.fixture_paths = [

--- a/spec/requests/browser_accounts_spec.rb
+++ b/spec/requests/browser_accounts_spec.rb
@@ -153,6 +153,32 @@ RSpec.describe "Browser accounts", type: :request do
       expect(flash[:error]).to include("maximum number of accounts")
       expect(browser_session.reload.account_count).to eq(BrowserSession::MAX_ACCOUNTS)
     end
+
+    # Two logins started side by side can both pass the cap check and only one can
+    # win the last slot. The loser used to raise AccountLimitError out of sign_in,
+    # mid-transaction, as a 500. Both stubs stand for state that was true a moment
+    # earlier in that race: the flag was set while there was still room, and the
+    # pre-check passed before the other request committed.
+    it "ends a login that loses the race for the last slot with a message, not a 500" do
+      sign_in_as(work)
+      (BrowserSession::MAX_ACCOUNTS - 1).times do |i|
+        add_account(create(:identity, primary_email: "extra#{i}@example.com"))
+      end
+
+      browser_session = BrowserSession.order(:created_at).last
+      expect(browser_session.account_count).to eq(BrowserSession::MAX_ACCOUNTS)
+
+      allow_any_instance_of(LoginsController).to receive(:adding_account?).and_return(true)
+      allow_any_instance_of(LoginsController).to receive(:browser_account_limit_reached?).and_return(false)
+
+      newcomer = create(:identity, primary_email: "one-too-many@example.com")
+      expect { sign_in_as(newcomer) }.not_to change { IdentitySession.count }
+
+      expect(response).to redirect_to(browser_accounts_path)
+      expect(flash[:error]).to include("maximum number of accounts")
+      expect(newcomer.sessions.reload).to be_empty
+      expect(browser_session.reload.account_count).to eq(BrowserSession::MAX_ACCOUNTS)
+    end
   end
 
   describe "with the flag off" do
@@ -169,6 +195,33 @@ RSpec.describe "Browser accounts", type: :request do
     end
   end
 
+  describe "when the active account expires with siblings still signed in" do
+    it "sends the user to the chooser rather than a login screen" do
+      sign_in_as(work)
+      personal_session = add_account(personal)
+      personal_session.update!(expires_at: 1.minute.ago)
+
+      get root_path
+
+      expect(response).to redirect_to(browser_accounts_path)
+
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(work.primary_email)
+    end
+
+    it "still goes to welcome when the chooser is switched off" do
+      sign_in_as(work)
+      personal_session = add_account(personal)
+      personal_session.update!(expires_at: 1.minute.ago)
+      Flipper.disable(BrowserAccountsController::FEATURE_FLAG)
+
+      get root_path
+
+      expect(response.headers["Location"]).to include(welcome_path)
+    end
+  end
+
   describe "sign-out" do
     it "signs out only the active account by default" do
       sign_in_as(work)
@@ -179,6 +232,19 @@ RSpec.describe "Browser accounts", type: :request do
       expect(personal.sessions.reload.select(&:live?)).to be_empty
       expect(work.sessions.reload.select(&:live?).size).to eq(1)
       expect(response).to redirect_to(browser_accounts_path)
+    end
+
+    # The browser session cookie survives; everything the departing account left
+    # in the Rails session does not.
+    it "discards the signed-out account's session data" do
+      sign_in_as(work)
+      add_account(personal)
+
+      delete logout_path
+
+      leftovers = session.to_hash.except("session_id", "_csrf_token", "flash")
+      expect(leftovers).to be_empty
+      expect(BrowserSession.count).to eq(1)
     end
 
     it "does not promote a sibling into the active slot" do

--- a/spec/requests/browser_accounts_spec.rb
+++ b/spec/requests/browser_accounts_spec.rb
@@ -29,10 +29,16 @@ RSpec.describe "Browser accounts", type: :request do
     end
 
     it "does not create a duplicate session when re-authenticating the same account" do
-      sign_in_as(work)
+      original = sign_in_as(work)
+      original.update!(expires_at: 1.minute.from_now)
+
       add_account(work)
 
-      expect(work.sessions.reload.select(&:live?).size).to eq(1)
+      renewed = work.sessions.reload.select(&:live?).sole
+      expect(renewed.id).not_to eq(original.id)
+      expect(renewed.expires_at).to be_within(5.seconds).of(SessionsHelper::SESSION_DURATION.from_now)
+      expect(original.reload.revoked_reason).to eq("reauthenticated")
+      expect(LoginAttempt.where(identity: work).order(:created_at).last.session).to eq(renewed)
     end
 
     it "records the addition without naming the other account" do
@@ -113,6 +119,21 @@ RSpec.describe "Browser accounts", type: :request do
 
       expect(BrowserSession.count).to eq(0)
       expect(response).to redirect_to(welcome_path)
+    end
+
+    it "keeps a parked authorization attached after removing an account" do
+      sign_in_as(personal)
+      add_account(work)
+      browser_session = BrowserSession.order(:created_at).last
+      pending = create(:pending_authorization, browser_session: browser_session)
+
+      get browser_accounts_path(pending: pending.token)
+      expect(response.body).to include(%(name="pending" value="#{pending.token}"))
+
+      delete browser_account_path(id: work.public_id), params: { pending: pending.token }
+
+      expect(response).to redirect_to(browser_accounts_path(pending: pending.token))
+      expect(pending.reload).not_to be_consumed
     end
   end
 

--- a/spec/requests/browser_accounts_spec.rb
+++ b/spec/requests/browser_accounts_spec.rb
@@ -1,0 +1,205 @@
+require "rails_helper"
+
+RSpec.describe "Browser accounts", type: :request do
+  let(:work) { create(:identity, primary_email: "nora@hackclub.com") }
+  let(:personal) { create(:identity, primary_email: "nora@example.com") }
+
+  before { Flipper.enable(BrowserAccountsController::FEATURE_FLAG) }
+  after { Flipper.disable(BrowserAccountsController::FEATURE_FLAG) }
+
+  describe "signing a second account into the same browser" do
+    it "keeps both accounts in one browser session" do
+      first = sign_in_as(work)
+      add_account(personal)
+
+      browser_session = first.reload.browser_session
+      expect(browser_session).to be_present
+      expect(browser_session.live_identity_sessions.map(&:identity)).to contain_exactly(work, personal)
+      expect(browser_session.active_identity).to eq(personal)
+    end
+
+    it "rotates the browser session token when an account is added" do
+      sign_in_as(work)
+      browser_session = BrowserSession.order(:created_at).last
+      token_before = browser_session.token
+
+      add_account(personal)
+
+      expect(browser_session.reload.token).not_to eq(token_before)
+    end
+
+    it "does not create a duplicate session when re-authenticating the same account" do
+      sign_in_as(work)
+      add_account(work)
+
+      expect(work.sessions.reload.select(&:live?).size).to eq(1)
+    end
+
+    it "records the addition without naming the other account" do
+      sign_in_as(work)
+      add_account(personal)
+
+      activity = PublicActivity::Activity.find_by(key: "identity_session.account_added")
+      expect(activity).to be_present
+      expect(activity.recipient_id).to eq(personal.id)
+      expect(activity.parameters.to_s).not_to include(work.primary_email)
+    end
+  end
+
+  describe "GET /accounts" do
+    before do
+      sign_in_as(work)
+      add_account(personal)
+      get browser_accounts_path
+    end
+
+    it "lists every account with its full email" do
+      expect(response.body).to include(work.primary_email)
+      expect(response.body).to include(personal.primary_email)
+    end
+
+    it "distinguishes work from personal with a text label, not colour alone" do
+      expect(response.body).to include("Hack Club")
+      expect(response.body).to include("Personal")
+    end
+  end
+
+  describe "switching" do
+    it "changes the active account" do
+      work_session = sign_in_as(work)
+      add_account(personal)
+
+      post switch_browser_account_path, params: { id: work.public_id }
+
+      expect(BrowserSession.order(:created_at).last.active_identity).to eq(work)
+      expect(work_session.reload).to be_live
+    end
+
+    it "refuses an account that isn't in this browser" do
+      sign_in_as(work)
+      stranger = create(:identity, primary_email: "stranger@example.com")
+
+      post switch_browser_account_path, params: { id: stranger.public_id }
+
+      expect(BrowserSession.order(:created_at).last.active_identity).to eq(work)
+    end
+
+    it "is not reachable by GET" do
+      sign_in_as(work)
+
+      get "/accounts/switch"
+
+      expect(response).to have_http_status(:not_found)
+    end
+  end
+
+  describe "removing an account" do
+    it "leaves the active account alone" do
+      sign_in_as(personal)
+      add_account(work)
+      post switch_browser_account_path, params: { id: personal.public_id }
+
+      delete browser_account_path(id: work.public_id)
+
+      expect(work.sessions.reload.select(&:live?)).to be_empty
+      expect(personal.sessions.reload.select(&:live?).size).to eq(1)
+      expect(BrowserSession.order(:created_at).last.active_identity).to eq(personal)
+    end
+
+    it "ends the browser session when the last account is removed" do
+      sign_in_as(work)
+
+      delete browser_account_path(id: work.public_id)
+
+      expect(BrowserSession.count).to eq(0)
+      expect(response).to redirect_to(welcome_path)
+    end
+  end
+
+  describe "the account cap" do
+    it "refuses to add more than MAX_ACCOUNTS and evicts nothing" do
+      sign_in_as(work)
+      (BrowserSession::MAX_ACCOUNTS - 1).times do |i|
+        add_account(create(:identity, primary_email: "extra#{i}@example.com"))
+      end
+
+      browser_session = BrowserSession.order(:created_at).last
+      expect(browser_session.account_count).to eq(BrowserSession::MAX_ACCOUNTS)
+
+      post add_browser_account_path
+
+      expect(response).to redirect_to(browser_accounts_path)
+      expect(flash[:error]).to include("maximum number of accounts")
+      expect(browser_session.reload.account_count).to eq(BrowserSession::MAX_ACCOUNTS)
+    end
+  end
+
+  describe "with the flag off" do
+    it "degrades to the active account instead of erroring" do
+      sign_in_as(work)
+      add_account(personal)
+      Flipper.disable(BrowserAccountsController::FEATURE_FLAG)
+
+      get browser_accounts_path
+      expect(response).to redirect_to(root_path)
+
+      get root_path
+      expect(response).to have_http_status(:ok).or redirect_to(anything)
+    end
+  end
+
+  describe "sign-out" do
+    it "signs out only the active account by default" do
+      sign_in_as(work)
+      add_account(personal)
+
+      delete logout_path
+
+      expect(personal.sessions.reload.select(&:live?)).to be_empty
+      expect(work.sessions.reload.select(&:live?).size).to eq(1)
+      expect(response).to redirect_to(browser_accounts_path)
+    end
+
+    it "does not promote a sibling into the active slot" do
+      sign_in_as(work)
+      add_account(personal)
+
+      delete logout_path
+
+      expect(BrowserSession.order(:created_at).last.active_session).to be_nil
+    end
+
+    it "signs out of everything on request" do
+      sign_in_as(work)
+      add_account(personal)
+
+      delete logout_all_path
+
+      expect(work.sessions.reload.select(&:live?)).to be_empty
+      expect(personal.sessions.reload.select(&:live?)).to be_empty
+      expect(BrowserSession.count).to eq(0)
+      expect(response).to redirect_to(welcome_path)
+    end
+  end
+
+  describe "legacy sessions" do
+    it "adopts a pre-multi-account cookie without signing the user out" do
+      sign_in_as(work)
+      browser_session = BrowserSession.order(:created_at).last
+      ident_session = browser_session.active_identity_session
+
+      # Rewind to the old world: cookie value points straight at the account
+      # session and no browser session exists.
+      legacy_token = browser_session.token
+      ident_session.update!(browser_session_id: nil, session_token: legacy_token)
+      browser_session.destroy!
+
+      get root_path
+
+      adopted = IdentitySession.find(ident_session.id).browser_session
+      expect(adopted).to be_present
+      expect(adopted.active_identity_session_id).to eq(ident_session.id)
+      expect(response).not_to redirect_to(welcome_path)
+    end
+  end
+end

--- a/spec/requests/oidc/account_selection_spec.rb
+++ b/spec/requests/oidc/account_selection_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe "OIDC account selection", type: :request do
       expect(pending.payload.dig("params", "prompt")).to eq("login")
     end
 
+    it "asks rather than handing over the only account when login_hint names another" do
+      authorize!(login_hint: "somebody-else@example.com")
+
+      expect(response).to redirect_to(%r{/accounts})
+    end
+
     it "succeeds silently for prompt=none" do
       approve!(prompt: "none")
 
@@ -126,6 +132,39 @@ RSpec.describe "OIDC account selection", type: :request do
       expect(other_pending.reload.consumed_at).to be_nil
     end
 
+    # Authenticating an account through "use another account" is itself the
+    # answer to "which account?". Asking again immediately afterwards is a loop
+    # the user can only escape by picking what they just typed a password for.
+    it "carries on into the flow after a third account signs in, without asking again" do
+      third = create(:identity, primary_email: "third@example.com")
+
+      authorize!(state: "xyz")
+      pending_token = PendingAuthorization.order(:created_at).last.token
+
+      post add_browser_account_path(pending: pending_token)
+      expect(response).to redirect_to(login_path(return_to: resume_browser_account_path(pending: pending_token)))
+
+      sign_in_as(third)
+
+      get resume_browser_account_path(pending: pending_token)
+      expect(response.headers["Location"]).to include("/oauth/authorize")
+
+      follow_redirect!
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(third.primary_email)
+      expect(response.body).not_to include(work.primary_email)
+    end
+
+    it "parks only authorize parameters, never Rails form fields" do
+      approve!(selected_account: personal.public_id, state: "xyz")
+
+      expect(response).to redirect_to(%r{/accounts})
+      parked = PendingAuthorization.order(:created_at).last.payload["params"]
+
+      expect(parked.keys).not_to include("authenticity_token", "commit", "_method", "utf8", "selected_account")
+      expect(parked).to include("client_id" => program.uid, "state" => "xyz", "nonce" => "test-nonce")
+    end
+
     describe "prompt=none" do
       it "returns account_selection_required on the redirect URI, preserving state" do
         authorize!(prompt: "none", state: "keep-me")
@@ -168,6 +207,23 @@ RSpec.describe "OIDC account selection", type: :request do
         expect(response).to redirect_to(%r{/step_up})
         expect(BrowserSession.order(:created_at).last.reload.active_identity).to eq(work)
       end
+
+      # Changing the active account is a change to the browser's state whoever
+      # asked for it, so it rotates the cookie and lands in the audit log just
+      # like a user-initiated switch.
+      it "rotates and audits the RP-driven switch" do
+        browser_session = BrowserSession.order(:created_at).last
+        browser_session.remember_selection!(kind: "oidc", ref: program.uid, identity: work)
+        token_before = browser_session.token
+        work_session = browser_session.live_identity_sessions.find_by(identity_id: work.id)
+
+        authorize!(prompt: "login")
+
+        expect(browser_session.reload.token).not_to eq(token_before)
+        expect(
+          PublicActivity::Activity.where(key: "identity_session.account_switched", trackable_id: work_session.id)
+        ).to exist
+      end
     end
 
     describe "login_hint" do
@@ -182,6 +238,16 @@ RSpec.describe "OIDC account selection", type: :request do
         authorize!(login_hint: "nobody@example.com")
 
         expect(response).to redirect_to(%r{/accounts})
+      end
+
+      it "is not overridden by a sticky selection for a different account" do
+        BrowserSession.order(:created_at).last
+          .remember_selection!(kind: "oidc", ref: program.uid, identity: work)
+
+        authorize!(login_hint: personal.primary_email)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(personal.primary_email)
       end
     end
 

--- a/spec/requests/oidc/account_selection_spec.rb
+++ b/spec/requests/oidc/account_selection_spec.rb
@@ -1,0 +1,238 @@
+require "rails_helper"
+
+RSpec.describe "OIDC account selection", type: :request do
+  let(:work) { create(:identity, primary_email: "nora@hackclub.com") }
+  let(:personal) { create(:identity, primary_email: "nora@example.com") }
+  let(:program) { create(:program, scopes: "openid email") }
+
+  before do
+    Flipper.enable(BrowserAccountsController::FEATURE_FLAG)
+    ensure_signing_key!
+  end
+
+  after do
+    Flipper.disable(BrowserAccountsController::FEATURE_FLAG)
+    Current.reset_all
+  end
+
+  def ensure_signing_key!
+    return if ENV["OIDC_SIGNING_KEY"].present?
+
+    Doorkeeper::OpenidConnect.configuration
+      .instance_variable_set(:@signing_key, OpenSSL::PKey::RSA.generate(2048).to_pem)
+  end
+
+  def authorize_params(extra = {})
+    {
+      client_id: program.uid,
+      redirect_uri: program.redirect_uri,
+      response_type: "code",
+      scope: "openid email",
+      nonce: "test-nonce"
+    }.merge(extra)
+  end
+
+  def authorize!(extra = {})
+    get "/oauth/authorize", params: authorize_params(extra)
+  end
+
+  def approve!(extra = {})
+    post "/oauth/authorize", params: authorize_params(extra)
+  end
+
+  def id_token_for(identity)
+    token = create(:oauth_token, resource_owner: identity, application: program, scopes: "openid email")
+    Doorkeeper::OpenidConnect::IdToken.new(token, "nonce").as_jws_token
+  end
+
+  def error_from_redirect
+    Rack::Utils.parse_query(URI.parse(response.headers["Location"]).query)["error"]
+  end
+
+  describe "with one account" do
+    before { sign_in_as(work) }
+
+    it "goes straight to the consent screen with no prompt" do
+      authorize!
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(work.primary_email)
+    end
+
+    it "renders the chooser for prompt=select_account instead of erroring" do
+      authorize!(prompt: "select_account")
+
+      expect(response).to redirect_to(%r{/accounts})
+    end
+
+    it "succeeds silently for prompt=none" do
+      approve!(prompt: "none")
+
+      expect(response.headers["Location"]).to include(program.redirect_uri)
+      expect(error_from_redirect).to be_nil
+    end
+  end
+
+  describe "with two accounts" do
+    before do
+      sign_in_as(work)
+      add_account(personal)
+    end
+
+    it "asks which account to use" do
+      authorize!
+
+      expect(response).to redirect_to(%r{/accounts\?.*pending=})
+    end
+
+    it "parks the request so it can be resumed intact" do
+      authorize!(state: "xyz")
+
+      pending = PendingAuthorization.order(:created_at).last
+      expect(pending.kind).to eq("oidc")
+      expect(pending.payload.dig("params", "state")).to eq("xyz")
+      expect(pending.payload.dig("params", "nonce")).to eq("test-nonce")
+    end
+
+    it "resumes the original request after a choice, exactly once" do
+      authorize!(state: "xyz")
+      pending_token = PendingAuthorization.order(:created_at).last.token
+
+      post switch_browser_account_path, params: { id: work.public_id, pending: pending_token }
+      expect(response).to redirect_to(resume_browser_account_path(pending: pending_token))
+
+      follow_redirect!
+      expect(response.headers["Location"]).to include("/oauth/authorize")
+      expect(response.headers["Location"]).to include("state=xyz")
+
+      # Replay is refused.
+      get resume_browser_account_path(pending: pending_token)
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "refuses a handle parked by a different browser session" do
+      other_pending = create(:pending_authorization)
+
+      get resume_browser_account_path(pending: other_pending.token)
+
+      expect(response).to redirect_to(root_path)
+      expect(other_pending.reload.consumed_at).to be_nil
+    end
+
+    describe "prompt=none" do
+      it "returns account_selection_required on the redirect URI, preserving state" do
+        authorize!(prompt: "none", state: "keep-me")
+
+        expect(response.headers["Location"]).to start_with(program.redirect_uri)
+        expect(error_from_redirect).to eq("account_selection_required")
+        expect(response.headers["Location"]).to include("state=keep-me")
+      end
+
+      it "resolves via a sticky selection" do
+        # prompt=none also requires prior consent, so grant it first — otherwise
+        # the (correct) consent_required masks whether selection worked.
+        create(:oauth_token, resource_owner: work, application: program, scopes: "openid email")
+        BrowserSession.order(:created_at).last
+          .remember_selection!(kind: "oidc", ref: program.uid, identity: work)
+
+        authorize!(prompt: "none")
+
+        expect(error_from_redirect).to be_nil
+        expect(Doorkeeper::AccessGrant.last.resource_owner_id).to eq(work.id)
+      end
+
+      it "resolves via login_hint" do
+        create(:oauth_token, resource_owner: personal, application: program, scopes: "openid email")
+
+        authorize!(prompt: "none", login_hint: personal.primary_email)
+
+        expect(error_from_redirect).to be_nil
+        expect(Doorkeeper::AccessGrant.last.resource_owner_id).to eq(personal.id)
+      end
+    end
+
+    describe "login_hint" do
+      it "selects the matching account without asking" do
+        authorize!(login_hint: work.primary_email)
+
+        expect(response).to have_http_status(:ok)
+        expect(response.body).to include(work.primary_email)
+      end
+
+      it "asks when it matches no signed-in account" do
+        authorize!(login_hint: "nobody@example.com")
+
+        expect(response).to redirect_to(%r{/accounts})
+      end
+    end
+
+    describe "id_token_hint" do
+      it "constrains selection to the named subject" do
+        authorize!(id_token_hint: id_token_for(work))
+
+        expect(error_from_redirect).to be_nil
+        expect(Doorkeeper::AccessGrant.last.resource_owner_id).to eq(work.id)
+      end
+
+      it "asks when the subject isn't signed in here" do
+        stranger = create(:identity, primary_email: "stranger@example.com")
+
+        authorize!(id_token_hint: id_token_for(stranger))
+
+        expect(response).to redirect_to(%r{/accounts})
+      end
+
+      it "rejects an unverifiable token" do
+        authorize!(id_token_hint: "not.a.jwt")
+
+        expect(error_from_redirect).to eq("invalid_request")
+      end
+    end
+
+    describe "the consent screen" do
+      it "shows the selected account, not the active one" do
+        BrowserSession.order(:created_at).last
+          .remember_selection!(kind: "oidc", ref: program.uid, identity: work)
+
+        authorize!
+
+        expect(response.body).to include(work.primary_email)
+        expect(response.body).not_to include(personal.primary_email)
+      end
+
+      it "carries the hints through the round-trip" do
+        BrowserSession.order(:created_at).last
+          .remember_selection!(kind: "oidc", ref: program.uid, identity: work)
+
+        authorize!(max_age: "3600", login_hint: work.primary_email)
+
+        expect(response.body).to include('name="max_age"')
+        expect(response.body).to include('name="login_hint"')
+        expect(response.body).to include('name="selected_account"')
+        # prompt must not round-trip, or select_account/consent would loop.
+        expect(response.body).not_to include('name="prompt"')
+      end
+
+      it "refuses to approve for an account other than the one displayed" do
+        BrowserSession.order(:created_at).last
+          .remember_selection!(kind: "oidc", ref: program.uid, identity: work)
+
+        approve!(selected_account: personal.public_id)
+
+        expect(response).to redirect_to(%r{/accounts})
+        expect(Doorkeeper::AccessGrant.count).to eq(0)
+      end
+    end
+  end
+
+  describe "discovery" do
+    it "advertises prompt and acr support" do
+      get "/.well-known/openid-configuration"
+
+      body = JSON.parse(response.body)
+      expect(body["prompt_values_supported"]).to include("select_account", "none", "login")
+      expect(body["acr_values_supported"]).to include(IdentitySession::ACR_MULTI_FACTOR)
+      expect(body["claims_supported"]).to include("amr", "acr", "auth_time")
+    end
+  end
+end

--- a/spec/requests/oidc/account_selection_spec.rb
+++ b/spec/requests/oidc/account_selection_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe "OIDC account selection", type: :request do
       expect(response).to redirect_to(%r{/accounts})
     end
 
+    it "removes select_account before parking the request" do
+      authorize!(prompt: "login select_account")
+
+      pending = PendingAuthorization.order(:created_at).last
+      expect(pending.payload.dig("params", "prompt")).to eq("login")
+    end
+
     it "succeeds silently for prompt=none" do
       approve!(prompt: "none")
 
@@ -151,6 +158,18 @@ RSpec.describe "OIDC account selection", type: :request do
       end
     end
 
+    describe "reauthentication" do
+      it "activates the selected sibling before prompt=login step-up" do
+        BrowserSession.order(:created_at).last
+          .remember_selection!(kind: "oidc", ref: program.uid, identity: work)
+
+        authorize!(prompt: "login")
+
+        expect(response).to redirect_to(%r{/step_up})
+        expect(BrowserSession.order(:created_at).last.reload.active_identity).to eq(work)
+      end
+    end
+
     describe "login_hint" do
       it "selects the matching account without asking" do
         authorize!(login_hint: work.primary_email)
@@ -186,6 +205,14 @@ RSpec.describe "OIDC account selection", type: :request do
         authorize!(id_token_hint: "not.a.jwt")
 
         expect(error_from_redirect).to eq("invalid_request")
+      end
+
+      it "does not redirect an unverifiable token to an unregistered URI" do
+        authorize!(id_token_hint: "not.a.jwt", redirect_uri: "https://attacker.example/callback")
+
+        expect(response).to have_http_status(:bad_request)
+        expect(response).not_to be_redirect
+        expect(JSON.parse(response.body)).to eq("error" => "invalid_request")
       end
     end
 

--- a/spec/requests/oidc_auth_time_spec.rb
+++ b/spec/requests/oidc_auth_time_spec.rb
@@ -1,0 +1,152 @@
+require "rails_helper"
+
+RSpec.describe "OIDC auth_time", type: :request do
+  let(:identity) { create(:identity) }
+  let(:program) { create(:program, scopes: "openid email") }
+  let(:session) { create(:identity_session, identity: identity) }
+
+  # Stub current_session; current_identity and identity_signed_in? derive from it
+  def sign_in_as(identity_session)
+    allow_any_instance_of(SessionsHelper).to receive(:current_session).and_return(identity_session)
+  end
+
+  before do
+    sign_in_as(session)
+
+    # ensure a signing key exists for ID token generation (may not be set in CI)
+    unless ENV["OIDC_SIGNING_KEY"].present?
+      key = OpenSSL::PKey::RSA.generate(2048).to_pem
+      Doorkeeper::OpenidConnect.configuration.instance_variable_set(:@signing_key, key)
+    end
+  end
+
+  after { Current.reset_all }
+
+  def expected_auth_time(s)
+    [ s.created_at, s.last_step_up_at ].compact.max.to_i
+  end
+
+  def decode_id_token(jwt)
+    JWT.decode(jwt, nil, false).first
+  end
+
+  # POST to /oauth/authorize to create the grant, returns [grant, code_string]
+  def authorize!(extra_params = {})
+    post "/oauth/authorize", params: {
+      client_id: program.uid,
+      redirect_uri: program.redirect_uri,
+      response_type: "code",
+      scope: "openid email",
+      nonce: "test-nonce"
+    }.merge(extra_params)
+
+    # Extract the code from the redirect location
+    location = response.headers["Location"]
+    code = CGI.parse(URI.parse(location).query)["code"].first
+    grant = Doorkeeper::AccessGrant.order(:created_at).last
+
+    [ grant, code ]
+  end
+
+  def exchange_code!(code)
+    post "/oauth/token", params: {
+      grant_type: "authorization_code",
+      code: code,
+      redirect_uri: program.redirect_uri,
+      client_id: program.uid,
+      client_secret: program.secret
+    }
+
+    JSON.parse(response.body)
+  end
+
+  describe "authorization code flow" do
+    it "stamps source_session_id on the grant" do
+      grant, _code = authorize!
+      expect(grant).to be_present
+      expect(grant.source_session_id).to eq(session.id)
+    end
+
+    it "returns correct auth_time after code exchange" do
+      _grant, code = authorize!
+      body = exchange_code!(code)
+
+      expect(response).to have_http_status(:ok)
+      expect(body["id_token"]).to be_present
+
+      claims = decode_id_token(body["id_token"])
+      expect(claims["auth_time"]).to eq(expected_auth_time(session))
+    end
+
+    it "uses the authorizing session, not the newest session" do
+      newer_session = identity.sessions.create!(
+        session_token: SecureRandom.hex(32),
+        expires_at: 1.week.from_now,
+        created_at: 1.hour.from_now
+      )
+
+      _grant, code = authorize!
+      body = exchange_code!(code)
+
+      claims = decode_id_token(body["id_token"])
+      expect(claims["auth_time"]).to eq(expected_auth_time(session))
+      expect(claims["auth_time"]).not_to eq(expected_auth_time(newer_session))
+    end
+
+    it "uses the original auth_time even if the source session has since expired" do
+      _grant, code = authorize!
+      session.update!(expires_at: 1.hour.ago)
+
+      body = exchange_code!(code)
+
+      claims = decode_id_token(body["id_token"])
+      expect(claims["auth_time"]).to eq(expected_auth_time(session))
+    end
+
+    it "reflects last_step_up_at when more recent than created_at" do
+      session.update!(last_step_up_at: 1.minute.from_now)
+
+      _grant, code = authorize!
+      body = exchange_code!(code)
+
+      claims = decode_id_token(body["id_token"])
+      expect(claims["auth_time"]).to eq(session.last_step_up_at.to_i)
+    end
+  end
+
+  describe "IdToken without session context" do
+    it "returns nil auth_time when neither source is available" do
+      Current.identity_session = nil
+
+      token = create(:oauth_token, resource_owner: identity, application: program, scopes: "openid email")
+      id_token = Doorkeeper::OpenidConnect::IdToken.new(token, "nonce")
+
+      expect(id_token.as_json[:auth_time]).to be_nil
+    end
+  end
+
+  describe "config blocks" do
+    describe "auth_time_from_resource_owner" do
+      let(:config_block) { Doorkeeper::OpenidConnect.configuration.auth_time_from_resource_owner }
+
+      it "returns auth_time from Current.identity_session" do
+        Current.identity_session = session
+
+        # The block is instance_exec'd by doorkeeper, so do the same here
+        controller = Object.new
+        result = controller.instance_exec(identity, &config_block)
+
+        expect(result).to eq([ session.created_at, session.last_step_up_at ].compact.max)
+      end
+
+      it "returns nil when Current.identity_session is not set" do
+        Current.identity_session = nil
+
+        controller = Object.new
+        result = controller.instance_exec(identity, &config_block)
+
+        expect(result).to be_nil
+      end
+    end
+  end
+end

--- a/spec/requests/saml_account_selection_spec.rb
+++ b/spec/requests/saml_account_selection_spec.rb
@@ -16,6 +16,10 @@ RSpec.describe "SAML account selection", type: :request do
   before do
     Flipper.enable(BrowserAccountsController::FEATURE_FLAG)
     Flipper.enable(:are_we_enterprise_yet_2025_10_21)
+    # Flipper state is global and other spec files leave this one on. A signed-in
+    # identity would then be bounced into verification before reaching the IdP
+    # endpoint, which made these examples pass alone and fail in a full run.
+    Flipper.disable(:persona_verification_2026_04_09)
     allow_any_instance_of(SAMLController).to receive(:ensure_sp_configured!) do |controller|
       controller.instance_variable_set(:@sp_config, sp_config)
       true
@@ -35,6 +39,9 @@ RSpec.describe "SAML account selection", type: :request do
     post idp_initiated_saml_path(slug: "airtable")
 
     expect(response).to have_http_status(:ok)
+    # An interstitial in a sign-in flow, not a page of the app: the signed-in
+    # chrome does not belong here, and its sidebar raised while rendering it.
+    expect(response.body).not_to include('id="sidebar"')
     offered_emails = Nokogiri::HTML(response.body).css(".account-email").map(&:text).map(&:strip)
     expect(offered_emails).to contain_exactly(allowed.primary_email, also_allowed.primary_email)
   end

--- a/spec/requests/saml_account_selection_spec.rb
+++ b/spec/requests/saml_account_selection_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+RSpec.describe "SAML account selection", type: :request do
+  let(:allowed) { create(:identity, primary_email: "nora@hackclub.com") }
+  let(:also_allowed) { create(:identity, primary_email: "max@hackclub.com") }
+  let(:disallowed) { create(:identity, primary_email: "nora@example.com") }
+  let(:sp_config) do
+    {
+      slug: "airtable",
+      entity_id: "https://airtable.example/saml",
+      allow_idp_initiated: true,
+      allowed_emails: [ allowed.primary_email, also_allowed.primary_email ]
+    }
+  end
+
+  before do
+    Flipper.enable(BrowserAccountsController::FEATURE_FLAG)
+    Flipper.enable(:are_we_enterprise_yet_2025_10_21)
+    allow_any_instance_of(SAMLController).to receive(:ensure_sp_configured!) do |controller|
+      controller.instance_variable_set(:@sp_config, sp_config)
+      true
+    end
+  end
+
+  after do
+    Flipper.disable(BrowserAccountsController::FEATURE_FLAG)
+    Flipper.disable(:are_we_enterprise_yet_2025_10_21)
+  end
+
+  it "offers eligible siblings before rejecting a disallowed active account" do
+    sign_in_as(allowed)
+    add_account(also_allowed)
+    add_account(disallowed)
+
+    post idp_initiated_saml_path(slug: "airtable")
+
+    expect(response).to have_http_status(:ok)
+    offered_emails = Nokogiri::HTML(response.body).css(".account-email").map(&:text).map(&:strip)
+    expect(offered_emails).to contain_exactly(allowed.primary_email, also_allowed.primary_email)
+  end
+
+  it "uses the sole eligible sibling instead of the disallowed active account" do
+    sign_in_as(allowed)
+    add_account(disallowed)
+
+    allow_any_instance_of(SAMLController).to receive(:build_saml_response).and_return(Object.new)
+    allow_any_instance_of(SAMLController).to receive(:render_saml_response) do |controller, **kwargs|
+      controller.render plain: kwargs.fetch(:identity).primary_email
+    end
+
+    post idp_initiated_saml_path(slug: "airtable")
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to eq(allowed.primary_email)
+  end
+end

--- a/spec/security/assurance_isolation_spec.rb
+++ b/spec/security/assurance_isolation_spec.rb
@@ -155,6 +155,20 @@ RSpec.describe "Authentication assurance isolation", type: :request do
     end
   end
 
+  # The token endpoint runs on a metal controller with no cookies and no session
+  # helpers. Reaching for them there raised on every single code exchange.
+  describe "the token endpoint" do
+    it "exchanges a code without tripping over browser-session lookups" do
+      sign_in_as(mfa_identity)
+      allow(Rails.logger).to receive(:warn).and_call_original
+
+      claims = authorize_and_exchange!(mfa_identity)
+
+      expect(claims["sub"]).to eq(mfa_identity.public_id)
+      expect(Rails.logger).not_to have_received(:warn).with(/Failed to remember account selection/)
+    end
+  end
+
   describe "grants" do
     it "stamps the selected account's session as the source" do
       sign_in_as(mfa_identity)

--- a/spec/security/assurance_isolation_spec.rb
+++ b/spec/security/assurance_isolation_spec.rb
@@ -1,0 +1,168 @@
+require "rails_helper"
+
+# The sharp edge of multi-account sessions: authentication assurance is per
+# account. Signing into a second account must never inherit the first account's
+# 2FA, step-up, or auth_time.
+RSpec.describe "Authentication assurance isolation", type: :request do
+  let(:mfa_identity) { enrol_totp(create(:identity, primary_email: "nora@hackclub.com")) }
+  let(:single_factor_identity) { create(:identity, primary_email: "nora@example.com") }
+  let(:program) { create(:program, scopes: "openid email") }
+
+  before do
+    Flipper.enable(BrowserAccountsController::FEATURE_FLAG)
+    unless ENV["OIDC_SIGNING_KEY"].present?
+      Doorkeeper::OpenidConnect.configuration
+        .instance_variable_set(:@signing_key, OpenSSL::PKey::RSA.generate(2048).to_pem)
+    end
+  end
+
+  after do
+    Flipper.disable(BrowserAccountsController::FEATURE_FLAG)
+    Current.reset_all
+  end
+
+  def authorize_and_exchange!(identity)
+    BrowserSession.order(:created_at).last
+      .remember_selection!(kind: "oidc", ref: program.uid, identity: identity)
+
+    post "/oauth/authorize", params: {
+      client_id: program.uid,
+      redirect_uri: program.redirect_uri,
+      response_type: "code",
+      scope: "openid email",
+      nonce: "test-nonce"
+    }
+
+    code = Rack::Utils.parse_query(URI.parse(response.headers["Location"]).query)["code"]
+
+    post "/oauth/token", params: {
+      grant_type: "authorization_code",
+      code: code,
+      redirect_uri: program.redirect_uri,
+      client_id: program.uid,
+      client_secret: program.secret
+    }
+
+    JWT.decode(JSON.parse(response.body)["id_token"], nil, false).first
+  end
+
+  describe "amr and acr" do
+    it "does not lend one account's MFA to another" do
+      mfa_session = sign_in_as(mfa_identity)
+      single_session = add_account(single_factor_identity)
+
+      expect(mfa_session.reload.amr_values).to include("mfa")
+      expect(single_session.reload.amr_values).not_to include("mfa")
+
+      claims = authorize_and_exchange!(single_factor_identity)
+
+      expect(claims["sub"]).to eq(single_factor_identity.public_id)
+      expect(claims["amr"]).not_to include("mfa")
+      expect(claims["acr"]).to eq(IdentitySession::ACR_SINGLE_FACTOR)
+      expect(claims["auth_time"]).to eq(single_session.reload.created_at.to_i)
+    end
+
+    it "reports the MFA account's own assurance when it is the one selected" do
+      sign_in_as(single_factor_identity)
+      mfa_session = add_account(mfa_identity)
+
+      claims = authorize_and_exchange!(mfa_identity)
+
+      expect(claims["sub"]).to eq(mfa_identity.public_id)
+      expect(claims["amr"]).to include("mfa")
+      expect(claims["acr"]).to eq(IdentitySession::ACR_MULTI_FACTOR)
+      expect(claims["auth_time"]).to eq(mfa_session.reload.created_at.to_i)
+    end
+
+    it "uses the selected account's auth_time even when a sibling session is newer" do
+      first = sign_in_as(single_factor_identity)
+      add_account(mfa_identity)
+
+      claims = authorize_and_exchange!(single_factor_identity)
+
+      newest = IdentitySession.order(created_at: :desc).first
+      expect(newest.identity_id).to eq(mfa_identity.id)
+      expect(claims["auth_time"]).to eq(first.reload.created_at.to_i)
+    end
+  end
+
+  describe "step-up" do
+    it "does not carry across accounts" do
+      mfa_session = sign_in_as(mfa_identity)
+      other_session = add_account(single_factor_identity)
+
+      mfa_session.record_step_up!(action: "oidc_reauth")
+
+      expect(mfa_session.reload.recently_stepped_up?(for_action: "oidc_reauth")).to be true
+      expect(other_session.reload.recently_stepped_up?(for_action: "oidc_reauth")).to be false
+    end
+
+    it "raises auth_time only for the account that stepped up" do
+      first = sign_in_as(single_factor_identity)
+      second = add_account(mfa_identity)
+
+      second.record_step_up!(action: "oidc_reauth")
+
+      claims = authorize_and_exchange!(single_factor_identity)
+      expect(claims["auth_time"]).to eq(first.reload.created_at.to_i)
+    end
+  end
+
+  describe "session lifetimes" do
+    it "expires accounts independently" do
+      first = sign_in_as(single_factor_identity)
+      second = add_account(mfa_identity)
+
+      first.update!(expires_at: 1.minute.ago)
+
+      expect(second.reload).to be_live
+      expect(BrowserSession.order(:created_at).last.live_identity_sessions).to contain_exactly(second)
+    end
+
+    it "does not extend an existing account's expiry when another is added" do
+      first = sign_in_as(single_factor_identity)
+      original = first.expires_at
+
+      add_account(mfa_identity)
+
+      expect(first.reload.expires_at).to be_within(2.seconds).of(original)
+    end
+  end
+
+  describe "consent" do
+    it "is never inherited from another account in the same browser" do
+      sign_in_as(single_factor_identity)
+      add_account(mfa_identity)
+
+      # single_factor_identity consents...
+      authorize_and_exchange!(single_factor_identity)
+      expect(Doorkeeper::AccessGrant.where(resource_owner_id: single_factor_identity.id)).to exist
+
+      # ...and the other account still has to be asked.
+      BrowserSession.order(:created_at).last
+        .remember_selection!(kind: "oidc", ref: program.uid, identity: mfa_identity)
+
+      get "/oauth/authorize", params: {
+        client_id: program.uid,
+        redirect_uri: program.redirect_uri,
+        response_type: "code",
+        scope: "openid email",
+        nonce: "test-nonce"
+      }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(mfa_identity.primary_email)
+    end
+  end
+
+  describe "grants" do
+    it "stamps the selected account's session as the source" do
+      sign_in_as(mfa_identity)
+      single_session = add_account(single_factor_identity)
+
+      authorize_and_exchange!(single_factor_identity)
+
+      expect(Doorkeeper::AccessGrant.last.source_session_id).to eq(single_session.id)
+    end
+  end
+end

--- a/spec/services/account_selection_resolver_spec.rb
+++ b/spec/services/account_selection_resolver_spec.rb
@@ -43,6 +43,19 @@ RSpec.describe AccountSelectionResolver, type: :model do
     it "proceeds silently for prompt=none" do
       expect(resolve(prompt: [ "none" ])).to be_proceed
     end
+
+    # Being the only account signed in is not a reason to hand it over when the
+    # RP named somebody else.
+    it "asks when a login_hint names a different account" do
+      expect(resolve(login_hint: "someone@else.com")).to be_chooser
+    end
+
+    it "errors rather than substituting for prompt=none with a login_hint it can't satisfy" do
+      decision = resolve(prompt: [ "none" ], login_hint: "someone@else.com")
+
+      expect(decision).to be_error
+      expect(decision.error).to eq(:account_selection_required)
+    end
   end
 
   context "with two accounts" do
@@ -95,6 +108,12 @@ RSpec.describe AccountSelectionResolver, type: :model do
         expect(decision).to be_chooser
         expect(decision.login_hint).to eq("someone@else.com")
       end
+
+      it "outranks a sticky selection it disagrees with" do
+        browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: work)
+
+        expect(resolve(login_hint: "someone@else.com")).to be_chooser
+      end
     end
 
     describe "id_token_hint" do
@@ -138,6 +157,13 @@ RSpec.describe AccountSelectionResolver, type: :model do
       it "resolves via login_hint" do
         expect(resolve(prompt: [ "none" ], login_hint: personal.primary_email).identity_session)
           .to eq(personal_session)
+      end
+
+      it "errors when a login_hint names an account that isn't here" do
+        decision = resolve(prompt: [ "none" ], login_hint: "nobody@example.com")
+
+        expect(decision).to be_error
+        expect(decision.error).to eq(:account_selection_required)
       end
 
       it "errors when an id_token_hint names an account that isn't here" do

--- a/spec/services/account_selection_resolver_spec.rb
+++ b/spec/services/account_selection_resolver_spec.rb
@@ -1,0 +1,201 @@
+require "rails_helper"
+
+RSpec.describe AccountSelectionResolver, type: :model do
+  let(:browser_session) { create(:browser_session) }
+  let(:work) { create(:identity, primary_email: "nora@hackclub.com") }
+  let(:personal) { create(:identity, primary_email: "nora@example.com") }
+
+  def sign_into(identity)
+    session = create(:identity_session, identity: identity, browser_session: browser_session)
+    browser_session.activate!(session)
+    session
+  end
+
+  def resolve(**overrides)
+    described_class.new(
+      browser_session: browser_session,
+      client_kind: "oidc",
+      client_ref: "client-abc",
+      **overrides
+    ).call
+  end
+
+  context "with nothing signed in" do
+    it "requires login" do
+      expect(resolve).to be_login_required
+    end
+  end
+
+  context "with one account" do
+    let!(:only) { sign_into(work) }
+
+    it "proceeds with no prompt" do
+      decision = resolve
+
+      expect(decision).to be_proceed
+      expect(decision.identity_session).to eq(only)
+    end
+
+    it "still shows the chooser for prompt=select_account" do
+      expect(resolve(prompt: [ "select_account" ])).to be_chooser
+    end
+
+    it "proceeds silently for prompt=none" do
+      expect(resolve(prompt: [ "none" ])).to be_proceed
+    end
+  end
+
+  context "with two accounts" do
+    let!(:work_session) { sign_into(work) }
+    let!(:personal_session) { sign_into(personal) }
+
+    it "asks when nothing indicates which" do
+      expect(resolve).to be_chooser
+    end
+
+    it "asks for prompt=select_account even with a sticky selection" do
+      browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: work)
+
+      decision = resolve(prompt: [ "select_account" ])
+
+      expect(decision).to be_chooser
+      expect(decision.preselect_identity).to eq(work)
+    end
+
+    it "uses the sticky selection when there is no prompt" do
+      browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: personal)
+
+      decision = resolve
+
+      expect(decision).to be_proceed
+      expect(decision.identity_session).to eq(personal_session)
+    end
+
+    it "ignores a sticky selection whose session is gone" do
+      # A third account keeps the choice ambiguous once the remembered one goes,
+      # so this tests the sticky lookup rather than the single-account shortcut.
+      sign_into(create(:identity, primary_email: "third@example.com"))
+      browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: personal)
+      personal_session.revoke!(reason: "user_signout")
+
+      expect(resolve).to be_chooser
+    end
+
+    describe "login_hint" do
+      it "preselects a matching account" do
+        decision = resolve(login_hint: "NORA@HACKCLUB.COM ")
+
+        expect(decision).to be_proceed
+        expect(decision.identity_session).to eq(work_session)
+      end
+
+      it "falls back to the chooser when it matches nothing" do
+        decision = resolve(login_hint: "someone@else.com")
+
+        expect(decision).to be_chooser
+        expect(decision.login_hint).to eq("someone@else.com")
+      end
+    end
+
+    describe "id_token_hint" do
+      it "constrains selection to the named subject" do
+        decision = resolve(id_token_hint_subject: personal.public_id)
+
+        expect(decision).to be_proceed
+        expect(decision.identity_session).to eq(personal_session)
+      end
+
+      it "does not substitute another account when the subject isn't here" do
+        decision = resolve(id_token_hint_subject: "ident_nobody")
+
+        expect(decision).to be_chooser
+        expect(decision.identity_session).to be_nil
+      end
+
+      it "outranks a sticky selection" do
+        browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: work)
+
+        decision = resolve(id_token_hint_subject: personal.public_id)
+
+        expect(decision.identity_session).to eq(personal_session)
+      end
+    end
+
+    describe "prompt=none" do
+      it "errors rather than guessing" do
+        decision = resolve(prompt: [ "none" ])
+
+        expect(decision).to be_error
+        expect(decision.error).to eq(:account_selection_required)
+      end
+
+      it "resolves via sticky selection" do
+        browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: work)
+
+        expect(resolve(prompt: [ "none" ]).identity_session).to eq(work_session)
+      end
+
+      it "resolves via login_hint" do
+        expect(resolve(prompt: [ "none" ], login_hint: personal.primary_email).identity_session)
+          .to eq(personal_session)
+      end
+
+      it "errors when an id_token_hint names an account that isn't here" do
+        decision = resolve(prompt: [ "none" ], id_token_hint_subject: "ident_nobody")
+
+        expect(decision).to be_error
+        expect(decision.error).to eq(:account_selection_required)
+      end
+    end
+
+    it "asks when the caller forces it" do
+      browser_session.remember_selection!(kind: "oidc", ref: "client-abc", identity: work)
+
+      expect(resolve(force_chooser: true)).to be_chooser
+    end
+  end
+
+  # SAML has no prompt parameter, so policy carries the whole load: ask on first
+  # use of an entity ID, remember the answer, and honour a forced re-ask.
+  describe "SAML service providers" do
+    let(:entity_id) { "https://sp.example.com/metadata" }
+
+    def resolve_saml(**overrides)
+      described_class.new(
+        browser_session: browser_session,
+        client_kind: "saml",
+        client_ref: entity_id,
+        **overrides
+      ).call
+    end
+
+    before do
+      sign_into(work)
+      sign_into(personal)
+    end
+
+    it "asks on first use" do
+      expect(resolve_saml).to be_chooser
+    end
+
+    it "is sticky per entity ID afterwards" do
+      browser_session.remember_selection!(kind: "saml", ref: entity_id, identity: work)
+
+      decision = resolve_saml
+      expect(decision).to be_proceed
+      expect(decision.identity_session.identity).to eq(work)
+    end
+
+    it "asks again when forced" do
+      browser_session.remember_selection!(kind: "saml", ref: entity_id, identity: work)
+
+      expect(resolve_saml(force_chooser: true)).to be_chooser
+    end
+
+    it "does not share a selection with the OIDC client of the same name" do
+      browser_session.remember_selection!(kind: "oidc", ref: entity_id, identity: work)
+
+      expect(resolve_saml).to be_chooser
+    end
+  end
+end

--- a/spec/services/id_token_hint_verifier_spec.rb
+++ b/spec/services/id_token_hint_verifier_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+RSpec.describe IdTokenHintVerifier, type: :model do
+  let(:identity) { create(:identity) }
+  let(:program) { create(:program, scopes: "openid email") }
+
+  before do
+    unless ENV["OIDC_SIGNING_KEY"].present?
+      Doorkeeper::OpenidConnect.configuration
+        .instance_variable_set(:@signing_key, OpenSSL::PKey::RSA.generate(2048).to_pem)
+    end
+  end
+
+  def issued_token(expires_in: 120)
+    token = create(:oauth_token, resource_owner: identity, application: program, scopes: "openid email")
+    Doorkeeper::OpenidConnect::IdToken.new(token, "nonce", expires_in).as_jws_token
+  end
+
+  it "returns no subject and no error for a blank hint" do
+    result = described_class.call(nil)
+
+    expect(result).not_to be_present
+    expect(result).not_to be_invalid
+  end
+
+  it "extracts the subject from a token we issued" do
+    result = described_class.call(issued_token, audience: program.uid)
+
+    expect(result.subject).to eq(identity.public_id)
+    expect(result).not_to be_invalid
+  end
+
+  # OIDC Core requires that an expired ID token still work as a hint — it is
+  # telling us who the user was last time, not authorising anything.
+  it "accepts an expired token" do
+    hint = issued_token(expires_in: -3600)
+
+    expect(described_class.call(hint, audience: program.uid).subject).to eq(identity.public_id)
+  end
+
+  it "rejects a token for a different client" do
+    result = described_class.call(issued_token, audience: "someone-elses-client-id")
+
+    expect(result).to be_invalid
+  end
+
+  it "rejects a token signed by someone else" do
+    foreign = JWT.encode(
+      { "iss" => "http://localhost:3000", "sub" => identity.public_id, "aud" => program.uid },
+      OpenSSL::PKey::RSA.generate(2048),
+      "RS256"
+    )
+
+    expect(described_class.call(foreign, audience: program.uid)).to be_invalid
+  end
+
+  it "rejects garbage" do
+    expect(described_class.call("not.a.jwt")).to be_invalid
+  end
+end

--- a/spec/support/authentication_helpers.rb
+++ b/spec/support/authentication_helpers.rb
@@ -1,0 +1,53 @@
+# Drives the real login flow rather than stubbing current_session.
+#
+# Stubbing is fine for specs that merely need "somebody is signed in", but every
+# spec in this feature is about how the cookie resolves to an account — stubbing
+# the resolver would prove nothing. This exercises the actual cookie.
+module AuthenticationHelpers
+  # Signs an identity in through /login, returning its IdentitySession.
+  # Handles the TOTP step when the identity requires two factors.
+  def sign_in_as(identity, return_to: nil)
+    post "/login", params: { email: identity.primary_email, return_to: return_to }.compact
+
+    attempt = LoginAttempt.where(identity: identity).order(:created_at).last
+    raise "no login attempt created for #{identity.primary_email}" if attempt.nil?
+
+    code = Identity::V2LoginCode.active.where(identity: identity).order(:created_at).last
+    raise "no login code issued for #{identity.primary_email}" if code.nil?
+
+    post "/login/#{attempt.to_param}/verify", params: { code: code.code }
+
+    complete_totp_step(identity, attempt) if identity.requires_two_factor?
+
+    identity.sessions.reload.order(:created_at).last
+  end
+
+  # Signs in a second (or third) account into the same browser session, the way
+  # "use another account" does.
+  def add_account(identity, pending: nil)
+    post add_browser_account_path(pending: pending)
+    sign_in_as(identity)
+  end
+
+  # Identity#totp only returns *verified* enrolments, so an unverified TOTP would
+  # leave requires_two_factor? false and silently produce a single-factor session.
+  def enrol_totp(identity)
+    identity.update!(use_two_factor_authentication: true)
+    Identity::TOTP.create!(identity: identity).mark_verified!
+    identity.reload
+  end
+
+  def current_browser_session_record
+    BrowserSession.order(:created_at).last
+  end
+
+  private
+
+  def complete_totp_step(identity, attempt)
+    totp = identity.totp
+    raise "#{identity.primary_email} requires two factors but has no TOTP" if totp.nil?
+
+    post "/login/#{attempt.to_param}/totp",
+      params: { code: ROTP::TOTP.new(totp.secret, issuer: Identity::TOTP::ISSUER).now }
+  end
+end

--- a/spec/views/doorkeeper/authorizations/new_spec.rb
+++ b/spec/views/doorkeeper/authorizations/new_spec.rb
@@ -26,8 +26,35 @@ RSpec.describe "doorkeeper/authorizations/new", type: :view do
   before do
     assign(:pre_auth, pre_auth)
     allow(view).to receive(:current_identity).and_return(identity)
+    # The account being authorized, which OidcAccountSelection supplies in the
+    # real controller. With several accounts in a browser it can differ from
+    # current_identity, and the view must describe this one.
+    allow(view).to receive(:authorizing_identity).and_return(identity)
+    allow(view).to receive(:account_chooser_available?).and_return(false)
     allow(Program).to receive(:find_by).and_return(program)
     allow(view).to receive(:oauth_authorization_path).and_return("/oauth/authorize")
+  end
+
+  # The email in the permissions rows is scope data; the one in the header names
+  # the account being handed over. They're different claims about different things.
+  def permissions_section
+    rendered[/<ul class="permissions-list">.*?<\/ul>/m].to_s
+  end
+
+  describe "the account being authorized" do
+    it "always names the account, even for openid-only scope" do
+      allow(pre_auth).to receive(:scopes).and_return(Doorkeeper::OAuth::Scopes.from_string("openid"))
+      render
+
+      expect(rendered).to include(I18n.t("accounts.signing_in_as"))
+      expect(rendered).to include(identity.primary_email)
+    end
+
+    it "labels a Hack Club address as such" do
+      render
+
+      expect(rendered).to include(I18n.t("accounts.kind.hack_club"))
+    end
   end
 
   describe "scope display" do
@@ -67,14 +94,16 @@ RSpec.describe "doorkeeper/authorizations/new", type: :view do
     it "deduplicates when email and basic_info are both requested" do
       allow(pre_auth).to receive(:scopes).and_return(Doorkeeper::OAuth::Scopes.from_string("email basic_info"))
       render
-      expect(rendered.scan(identity.primary_email).count).to eq(1)
+      # Scoped to the permissions list: the email also appears in the
+      # "signing in as" header, which is deliberate and always shown.
+      expect(permissions_section.scan(identity.primary_email).count).to eq(1)
     end
 
     it "shows nothing for openid-only scope" do
       allow(pre_auth).to receive(:scopes).and_return(Doorkeeper::OAuth::Scopes.from_string("openid"))
       render
-      expect(rendered).not_to include(identity.primary_email)
-      expect(rendered).not_to include(identity.first_name)
+      expect(permissions_section).not_to include(identity.primary_email)
+      expect(permissions_section).not_to include(identity.first_name)
     end
 
     it "falls back to i18n for unknown scopes" do


### PR DESCRIPTION
When users have more than one HCA account for one reason or another, switching accounts is downright annoying. This adds a account switcher seen in indie services like Google.