### PR TITLE
Re-provision Slack after primary email changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,5 @@ jobs:
           bundler-cache: true
 
       - name: Lint code for consistent style
-        run: bin/rubocop -f github
+        run: bin/rubocop
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,5 +41,5 @@ jobs:
           bundler-cache: true
 
       - name: Lint code for consistent style
-        run: bin/rubocop
+        run: bin/rubocop -f github
 

--- a/README.md
+++ b/README.md
@@ -172,3 +172,5 @@ then set `OIDC_SIGNING_KEY` to the contents of `oidc_key.pem` (the whole thing i
 
 this oughta go without saying, but if you find a security-relevant issue please either contact me directly or go through the security.hackclub.com flow –
 if you just open an issue or a PR there's a chance a bad actor sees it and exploits it before we can patch or merge.
+
+#temp change

--- a/README.md
+++ b/README.md
@@ -172,5 +172,3 @@ then set `OIDC_SIGNING_KEY` to the contents of `oidc_key.pem` (the whole thing i
 
 this oughta go without saying, but if you find a security-relevant issue please either contact me directly or go through the security.hackclub.com flow –
 if you just open an issue or a PR there's a chance a bad actor sees it and exploits it before we can patch or merge.
-
-#temp change

--- a/README.md
+++ b/README.md
@@ -172,3 +172,6 @@ then set `OIDC_SIGNING_KEY` to the contents of `oidc_key.pem` (the whole thing i
 
 this oughta go without saying, but if you find a security-relevant issue please either contact me directly or go through the security.hackclub.com flow –
 if you just open an issue or a PR there's a chance a bad actor sees it and exploits it before we can patch or merge.
+
+# temp test
+

--- a/app/models/identity/email_change_request.rb
+++ b/app/models/identity/email_change_request.rb
@@ -137,6 +137,7 @@ class Identity::EmailChangeRequest < ApplicationRecord
       end
 
       identity.update!(primary_email: new_email)
+      SCIMService.reprovision_identity_after_primary_email_change(identity:)
       identity.sessions.not_expired.update_all(signed_out_at: Time.current, expires_at: Time.current)
       identity.all_access_tokens.where(revoked_at: nil).update_all(revoked_at: Time.current)
       update!(completed_at: Time.current)

--- a/app/models/identity/email_change_request.rb
+++ b/app/models/identity/email_change_request.rb
@@ -228,9 +228,9 @@ class Identity::EmailChangeRequest < ApplicationRecord
     return unless completed_at.present?
     return unless both_emails_verified?
 
-    idenitity.reload
+    identity.reload
     return unless identity.primary_email == new_email
 
-    SCIMService.reprovision_identity_after_primary_email_change(idenity:)
+    SCIMService.reprovision_identity_after_primary_email_change(identity:)
   end
 end

--- a/app/models/identity/email_change_request.rb
+++ b/app/models/identity/email_change_request.rb
@@ -62,6 +62,7 @@ class Identity::EmailChangeRequest < ApplicationRecord
   before_validation :set_defaults, on: :create
   before_create :generate_tokens
   after_create :track_email_change_requested
+  after_commit :reprovision_slack_after_completion, on :update
 
   def pending?
     completed_at.nil? && cancelled_at.nil? && !expired?
@@ -137,7 +138,6 @@ class Identity::EmailChangeRequest < ApplicationRecord
       end
 
       identity.update!(primary_email: new_email)
-      SCIMService.reprovision_identity_after_primary_email_change(identity:)
       identity.sessions.not_expired.update_all(signed_out_at: Time.current, expires_at: Time.current)
       identity.all_access_tokens.where(revoked_at: nil).update_all(revoked_at: Time.current)
       update!(completed_at: Time.current)
@@ -221,5 +221,13 @@ class Identity::EmailChangeRequest < ApplicationRecord
     unless address.valid_mx?
       errors.add(:new_email, I18n.t("errors.attributes.new_email.no_mx_record", default: "domain does not accept email"))
     end
+  end
+
+  def reprovision_slack_after_completion
+    return unless saved_change_to_completed_at? && completed_at.present?
+    return unless both_emails_verified?
+    return unless identity.primary_email == new_email
+
+    SCIMService.reprovision_identity_after_primary_email_change(idenity:)
   end
 end

--- a/app/models/identity/email_change_request.rb
+++ b/app/models/identity/email_change_request.rb
@@ -62,7 +62,7 @@ class Identity::EmailChangeRequest < ApplicationRecord
   before_validation :set_defaults, on: :create
   before_create :generate_tokens
   after_create :track_email_change_requested
-  after_commit :reprovision_slack_after_completion, on :update
+  after_commit :reprovision_slack_after_completion, on: :update
 
   def pending?
     completed_at.nil? && cancelled_at.nil? && !expired?
@@ -224,8 +224,11 @@ class Identity::EmailChangeRequest < ApplicationRecord
   end
 
   def reprovision_slack_after_completion
-    return unless saved_change_to_completed_at? && completed_at.present?
+    return unless saved_change_to_completed_at?
+    return unless completed_at.present?
     return unless both_emails_verified?
+
+    idenitity.reload
     return unless identity.primary_email == new_email
 
     SCIMService.reprovision_identity_after_primary_email_change(idenity:)

--- a/app/services/scim_service.rb
+++ b/app/services/scim_service.rb
@@ -2,6 +2,51 @@ module SCIMService
   class << self
     SCIM_BASE_URL = "https://api.slack.com/scim/v2"
 
+    def reprovision_identityafter_primary_email_change(identity:)
+      return if identity.slack_id.blank?
+
+      scenario = identity.onboarding_scenario_instance
+      result = find_or_create_user(identity:, scenario)
+
+      unless result[:success]
+        Rails.logger.warn(
+          "Slack reprovision after email change failed for identity 
+          #{indentity.public_id}: #{result[:error]}"
+        )
+        return
+      end
+
+      new_slack_id = result[:slack_id]
+      current_slack_id = indentity.slack_id
+
+      if new_slack_id == current_slack_id
+        Rails.logger.info(
+          "Slack reprovision after email change kept existing Slack ID for identity
+          #{indentity.public_id}: #{current_slack_id}"
+        )
+        return
+      end
+
+      indentity.update!(slack_id: new_slack_id)
+      Rails.logger.info(
+        "Slack Reprovision after email change updated Slack ID for indentity
+        #{indentity.public_id}: #{current_slack_id} -> #{new_slack_id}"
+      )
+      identity.create_activity :slack_account_linked,
+        owner: identity,
+        recipient: identity,
+        parameters: { slack_id: new_slack_id}
+    rescue => e
+      Rails.logger.error("Error reprovisoning Slack ID after email change: #{e.message}")
+      Sentry.capture_exeption(e,
+      tags: {component: "slack", operation: "scim_reprovision_after_email_change"},
+      extra: {
+        identity_public_id: identity.public_id,
+        identity_email: identity.primary_email,
+        current_slack_id: identity.slack_id
+      })
+    end
+
     def find_or_create_user(identity:, scenario:)
       if Rails.env.staging?
         Rails.logger.info "Skipping Slack provisioning in staging for #{identity.primary_email}"

--- a/app/services/scim_service.rb
+++ b/app/services/scim_service.rb
@@ -10,8 +10,7 @@ module SCIMService
 
       unless result[:success]
         Rails.logger.warn(
-          "Slack reprovision after email change failed for identity 
-          #{identity.public_id}: #{result[:error]}"
+          "Slack reprovision after email change failed for identity #{identity.public_id}: #{result[:error]}"
         )
         return
       end
@@ -24,7 +23,7 @@ module SCIMService
         )
         return
       end
-      
+
       if new_slack_id == current_slack_id
         Rails.logger.info(
           "Slack reprovision after email change kept existing Slack ID for identity
@@ -41,11 +40,11 @@ module SCIMService
       identity.create_activity :slack_account_linked,
         owner: identity,
         recipient: identity,
-        parameters: { slack_id: new_slack_id}
+        parameters: { slack_id: new_slack_id }
     rescue => e
       Rails.logger.error("Error reprovisioning Slack ID after email change: #{e.message}")
       Sentry.capture_exception(e,
-      tags: {component: "slack", operation: "scim_reprovision_after_email_change"},
+      tags: { component: "slack", operation: "scim_reprovision_after_email_change"},
       extra: {
         identity_public_id: identity.public_id,
         identity_email: identity.primary_email,

--- a/app/services/scim_service.rb
+++ b/app/services/scim_service.rb
@@ -2,7 +2,7 @@ module SCIMService
   class << self
     SCIM_BASE_URL = "https://api.slack.com/scim/v2"
 
-    def reprovision_identityafter_primary_email_change(identity:)
+    def reprovision_identity_after_primary_email_change(identity:)
       return if identity.slack_id.blank?
 
       scenario = identity.onboarding_scenario_instance
@@ -11,16 +11,16 @@ module SCIMService
       unless result[:success]
         Rails.logger.warn(
           "Slack reprovision after email change failed for identity 
-          #{indentity.public_id}: #{result[:error]}"
+          #{identity.public_id}: #{result[:error]}"
         )
         return
       end
 
       new_slack_id = result[:slack_id]
-      current_slack_id = indentity.slack_id
+      current_slack_id = identity.slack_id
       if new_slack_id.blank?
         Rails.logger.warn(
-          "Slack reprovision after email change returned blank ID for identity #{idenitity.public_id}"
+          "Slack reprovision after email change returned blank ID for identity #{identity.public_id}"
         )
         return
       end
@@ -28,23 +28,23 @@ module SCIMService
       if new_slack_id == current_slack_id
         Rails.logger.info(
           "Slack reprovision after email change kept existing Slack ID for identity
-          #{indentity.public_id}: #{current_slack_id}"
+          #{identity.public_id}: #{current_slack_id}"
         )
         return
       end
 
-      indentity.update!(slack_id: new_slack_id)
+      identity.update!(slack_id: new_slack_id)
       Rails.logger.info(
-        "Slack Reprovision after email change updated Slack ID for indentity
-        #{indentity.public_id}: #{current_slack_id} -> #{new_slack_id}"
+        "Slack Reprovision after email change updated Slack ID for identity
+        #{identity.public_id}: #{current_slack_id} -> #{new_slack_id}"
       )
       identity.create_activity :slack_account_linked,
         owner: identity,
         recipient: identity,
         parameters: { slack_id: new_slack_id}
     rescue => e
-      Rails.logger.error("Error reprovisoning Slack ID after email change: #{e.message}")
-      Sentry.capture_exeption(e,
+      Rails.logger.error("Error reprovisioning Slack ID after email change: #{e.message}")
+      Sentry.capture_exception(e,
       tags: {component: "slack", operation: "scim_reprovision_after_email_change"},
       extra: {
         identity_public_id: identity.public_id,

--- a/app/services/scim_service.rb
+++ b/app/services/scim_service.rb
@@ -6,7 +6,7 @@ module SCIMService
       return if identity.slack_id.blank?
 
       scenario = identity.onboarding_scenario_instance
-      result = find_or_create_user(identity:, scenario)
+      result = find_or_create_user(identity:, scenario:)
 
       unless result[:success]
         Rails.logger.warn(

--- a/app/services/scim_service.rb
+++ b/app/services/scim_service.rb
@@ -44,7 +44,7 @@ module SCIMService
     rescue => e
       Rails.logger.error("Error reprovisioning Slack ID after email change: #{e.message}")
       Sentry.capture_exception(e,
-      tags: { component: "slack", operation: "scim_reprovision_after_email_change"},
+      tags: { component: "slack", operation: "scim_reprovision_after_email_change" },
       extra: {
         identity_public_id: identity.public_id,
         identity_email: identity.primary_email,

--- a/app/services/scim_service.rb
+++ b/app/services/scim_service.rb
@@ -18,7 +18,13 @@ module SCIMService
 
       new_slack_id = result[:slack_id]
       current_slack_id = indentity.slack_id
-
+      if new_slack_id.blank?
+        Rails.logger.warn(
+          "Slack reprovision after email change returned blank ID for identity #{idenitity.public_id}"
+        )
+        return
+      end
+      
       if new_slack_id == current_slack_id
         Rails.logger.info(
           "Slack reprovision after email change kept existing Slack ID for identity

--- a/spec/models/identity/email_change_request_spec.rb
+++ b/spec/models/identity/email_change_request_spec.rb
@@ -189,7 +189,7 @@ RSpec.describe Identity::EmailChangeRequest do
     
     it "invokes Slack reprovisioning via the after_commit callback" do
       expect(SCIMService)
-      .to recieve(:reprovision_identity_after_primary_email_change)
+      .to receive(:reprovision_identity_after_primary_email_change)
       .once do |identity:|
         expect(identity.primary_email). to eq("new@hackclub.com")
       end
@@ -199,7 +199,7 @@ RSpec.describe Identity::EmailChangeRequest do
     end
 
     it "still completes if Slack reprovisioning raises" do
-      oringinal_slack_id = idenity.slack_id
+      original_slack_id = identity.slack_id
       allow(SCIMService).to receive(:reprovision_identity_after_primary_email_change).and_raise(StandardError, "Slack is down")
       expect {
         request.verify_old_email!(request.old_email_token)
@@ -207,8 +207,8 @@ RSpec.describe Identity::EmailChangeRequest do
       }.not_to raise_error
 
       request.reload
-      idenity.reload
-      
+      identity.reload
+
       expect(request).to be_completed
       expect(request.completed_at).to be_present
       expect(identity.reload.primary_email).to eq("new@hackclub.com")
@@ -221,29 +221,29 @@ RSpec.describe Identity::EmailChangeRequest do
     let(:identity) {create(:identity, primary_email: "old@hackclub.com", slack_id: "UOLD12345") }
 
     before do
-      allow(identity).to recieve(:onboarding_scenario_instance).and_return(scenario)
+      allow(identity).to receive(:onboarding_scenario_instance).and_return(scenario)
     end
 
     it "keeps existing Slack account when resolved Slack account is the same" do 
-      allow(SCIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
+      allow(SCIMService).to receive(:find_or_create_user).with(identity:, scenario:).and_return(
         success: true, slack_id: "UOLD12345", created: false
       )
 
-      expect(identity).not_to recieve(:update!)
+      expect(identity).not_to receive(:update!)
       expect {
-        SCIMService.reprovision_identity_after_primary_email_change(idenity:)
+        SCIMService.reprovision_identity_after_primary_email_change(identity:)
       }.not_to change {identity.activities.count}
       expect(identity.reload.slack_id).to eq("UOLD12345")
     end
 
     it "updates to a different existing Slack account when found" do
-      allow(SCIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
-        sucess: true, slack_id: "UEXISTING9", created: false
+      allow(SCIMService).to receive(:find_or_create_user).with(identity:, scenario:).and_return(
+        success: true, slack_id: "UEXISTING9", created: false
       )
 
       expect {
         SCIMService.reprovision_identity_after_primary_email_change(identity:)
-      }.to change { indentity.reload.slack_id }.from("UOLD12345").to("UXISTING9")
+      }.to change { identity.reload.slack_id }.from("UOLD12345").to("UEXISTING9")
 
       activity = identity.activities.find_by(key: "identity.slack_account_linked")
       expect(activity).to be_present
@@ -251,7 +251,7 @@ RSpec.describe Identity::EmailChangeRequest do
     end
 
     it "updates to a new Slack account when created" do
-      allow(SCIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
+      allow(SCIMService).to receive(:find_or_create_user).with(identity:, scenario:).and_return(
         success: true, slack_id: "UNEW123456", created: true
       )
 
@@ -259,7 +259,7 @@ RSpec.describe Identity::EmailChangeRequest do
         SCIMService.reprovision_identity_after_primary_email_change(identity:)
       }.to change { identity.reload.slack_id}.from("UOLD12345").to("UNEW123456")
       
-      activity = identity.activate.find_by(key: "identity.slack_account_linked")
+      activity = identity.activities.find_by(key: "identity.slack_account_linked")
       expect(activity).to be_present
       expect(activity.parameters[:slack_id]).to eq("UNEW123456")
     end
@@ -275,7 +275,7 @@ RSpec.describe Identity::EmailChangeRequest do
     end
 
     it "keeps existing Slack ID when reprovisioning fails" do
-      allow(SKIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
+      allow(SCIMService).to receive(:find_or_create_user).with(identity:, scenario:).and_return(
         success: false, error: "lookup faled", created: false
       )
 
@@ -285,13 +285,13 @@ RSpec.describe Identity::EmailChangeRequest do
     end
 
     it "keeps existing Slack ID when reprovisioning returns blank Slack ID" do
-      allow(SKIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
+      allow(SCIMService).to receive(:find_or_create_user).with(identity:, scenario:).and_return(
         success: true, slack_id: nil, created: false
       )
 
-      expect(idenity).not_to recieve(:update!)
-      SKIMService.reprovision_indentity_after_primary_email_change(idenity:)
-      expect(idenity.reload.slack_id).to eq("UOLD12345")
+      expect(identity).not_to receive(:update!)
+      SCIMService.reprovision_identity_after_primary_email_change(identity:)
+      expect(identity.reload.slack_id).to eq("UOLD12345")
     end
   end
 

--- a/spec/models/identity/email_change_request_spec.rb
+++ b/spec/models/identity/email_change_request_spec.rb
@@ -271,13 +271,23 @@ RSpec.describe Identity::EmailChangeRequest do
     end
 
     it "keeps existing Slack ID when reprovisioning fails" do
-      allow(SKIMService).to recieve(:find_or_create_user).with(identity:,scenario:).and_return(
+      allow(SKIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
         success: false, error: "lookup faled", created: false
       )
 
       expect(identity).not_to receive(:update!)
       SCIMService.reprovision_identity_after_primary_email_change(identity:)
       expect(identity.reload.slack_id).to eq("UOLD12345")
+    end
+
+    it "keeps existing Slack ID when reprovisioning returns blank Slack ID" do
+      allow(SKIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
+        success: true, slack_id: nil, created: false
+      )
+
+      expect(idenity).not_to recieve(:update!)
+      SKIMService.reprovision_indentity_after_primary_email_change(idenity:)
+      expect(idenity.reload.slack_id).to eq("UOLD12345")
     end
   end
 

--- a/spec/models/identity/email_change_request_spec.rb
+++ b/spec/models/identity/email_change_request_spec.rb
@@ -186,14 +186,14 @@ RSpec.describe Identity::EmailChangeRequest do
       expect(activity.parameters[:old_email]).to eq(original_email)
       expect(activity.parameters[:new_email]).to eq("new@hackclub.com")
     end
-    
+
     it "invokes Slack reprovisioning via the after_commit callback" do
       expect(SCIMService)
       .to receive(:reprovision_identity_after_primary_email_change)
       .once do |identity:|
         expect(identity.primary_email). to eq("new@hackclub.com")
       end
-      
+
       request.verify_old_email!(request.old_email_token)
       request.verify_new_email!(request.new_email_token)
     end
@@ -213,18 +213,18 @@ RSpec.describe Identity::EmailChangeRequest do
       expect(request.completed_at).to be_present
       expect(identity.reload.primary_email).to eq("new@hackclub.com")
       expect(identity.reload.slack_id).to eq(original_slack_id)
-    end 
+    end
   end
 
   describe "SCIMService.reprovision_identity_after_primary_email_change" do
     let(:scenario) { instance_double("OnboardingScenarios::Base") }
-    let(:identity) {create(:identity, primary_email: "old@hackclub.com", slack_id: "UOLD12345") }
+    let(:identity) { create(:identity, primary_email: "old@hackclub.com", slack_id: "UOLD12345") }
 
     before do
       allow(identity).to receive(:onboarding_scenario_instance).and_return(scenario)
     end
 
-    it "keeps existing Slack account when resolved Slack account is the same" do 
+    it "keeps existing Slack account when resolved Slack account is the same" do
       allow(SCIMService).to receive(:find_or_create_user).with(identity:, scenario:).and_return(
         success: true, slack_id: "UOLD12345", created: false
       )
@@ -232,7 +232,7 @@ RSpec.describe Identity::EmailChangeRequest do
       expect(identity).not_to receive(:update!)
       expect {
         SCIMService.reprovision_identity_after_primary_email_change(identity:)
-      }.not_to change {identity.activities.count}
+      }.not_to change { identity.activities.count }
       expect(identity.reload.slack_id).to eq("UOLD12345")
     end
 
@@ -257,8 +257,8 @@ RSpec.describe Identity::EmailChangeRequest do
 
       expect {
         SCIMService.reprovision_identity_after_primary_email_change(identity:)
-      }.to change { identity.reload.slack_id}.from("UOLD12345").to("UNEW123456")
-      
+      }.to change { identity.reload.slack_id }.from("UOLD12345").to("UNEW123456")
+
       activity = identity.activities.find_by(key: "identity.slack_account_linked")
       expect(activity).to be_present
       expect(activity.parameters[:slack_id]).to eq("UNEW123456")
@@ -269,7 +269,7 @@ RSpec.describe Identity::EmailChangeRequest do
         success: false, error: "lookup failed", created: false
       )
 
-      expect { 
+      expect {
         SCIMService.reprovision_identity_after_primary_email_change(identity:)
       }.not_to raise_error
     end

--- a/spec/models/identity/email_change_request_spec.rb
+++ b/spec/models/identity/email_change_request_spec.rb
@@ -186,6 +186,99 @@ RSpec.describe Identity::EmailChangeRequest do
       expect(activity.parameters[:old_email]).to eq(original_email)
       expect(activity.parameters[:new_email]).to eq("new@hackclub.com")
     end
+    
+    it "reprovisions Slack after completion" do
+      expect(SCIMService).to recieve(:reprovision_identity_after_primary_email_change) do |identity:|
+        expect(identity.primary_email). to eq("new@hackclub.com")
+      end
+      
+      request.verify_old_email!(request.old_email_token)
+      request.verify_new_email!(request.new_email_token)
+    end
+
+    it "still completes if Slack reprovisioning raises" do
+      scenario = instance_double("OnboardingScenarios::Base")
+      allow(request.identity).to recieve(:onboarding_scenario_instance).and_return(scenario)
+      allow(SCIMService).to receive(:find_or_create_user).and_raise(StandardError, "Slack is down")
+
+      original_slack_id = identity.slack_id
+
+      request.verify_old_email!(request.old_email_token)
+      request.verify_new_email!(request.new_email_token)
+
+      expect(request.reload).to be_completed
+      expect(identity.reload.primary_email).to eq("new@hackclub.com")
+      expect(identity.reload.slack_id).to eq(original_slack_id)
+    end 
+  end
+
+  describe "SCIMService.reprovision_identity_after_primary_email_change" do
+    let(:scenario) { instance_double("OnboardingScenarios::Base") }
+    let(:identity) {create(:identity, primary_email: "old@hackclub.com", slack_id: "UOLD12345") }
+
+    before do
+      allow(identity).to recieve(:onboarding_scenario_instance).and_return(scenario)
+    end
+
+    it "keeps existing Slack account when resolved Slack account is the same" do 
+      allow(SCIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
+        success: true, slack_id: "UOLD12345", created: false
+      )
+
+      expect(identity).not_to recieve(:update!)
+      expect {
+        SCIMService.reprovision_identity_after_primary_email_change(idenity:)
+      }.not_to change {identity.activities.count}
+      expect(identity.reload.slack_id).to eq("UOLD12345")
+    end
+
+    it "updates to a different existing Slack account when found" do
+      allow(SCIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
+        sucess: true, slack_id: "UEXISTING9", created: false
+      )
+
+      expect {
+        SCIMService.reprovision_identity_after_primary_email_change(identity:)
+      }.to change { indentity.reload.slack_id }.from("UOLD12345").to("UXISTING9")
+
+      activity = identity.activities.find_by(key: "identity.slack_account_linked")
+      expect(activity).to be_present
+      expect(activity.parameters[:slack_id]).to eq("UEXISTING9")
+    end
+
+    it "updates to a new Slack account when created" do
+      allow(SCIMService).to recieve(:find_or_create_user).with(identity:, scenario:).and_return(
+        success: true, slack_id: "UNEW123456", created: true
+      )
+
+      expect {
+        SCIMService.reprovision_identity_after_primary_email_change(identity:)
+      }.to change { identity.reload.slack_id}.from("UOLD12345").to("UNEW123456")
+      
+      activity = identity.activate.find_by(key: "identity.slack_account_linked")
+      expect(activity).to be_present
+      expect(activity.parameters[:slack_id]).to eq("UNEW123456")
+    end
+
+    it "handles SCIM lookup/provisioning failure without raising" do
+      allow(SCIMService).to receive(:find_or_create_user).with(identity:, scenario:).and_return(
+        success: false, error: "lookup failed", created: false
+      )
+
+      expect { 
+        SCIMService.reprovision_identity_after_primary_email_change(identity:)
+      }.not_to raise_error
+    end
+
+    it "keeps existing Slack ID when reprovisioning fails" do
+      allow(SKIMService).to recieve(:find_or_create_user).with(identity:,scenario:).and_return(
+        success: false, error: "lookup faled", created: false
+      )
+
+      expect(identity).not_to receive(:update!)
+      SCIMService.reprovision_identity_after_primary_email_change(identity:)
+      expect(identity.reload.slack_id).to eq("UOLD12345")
+    end
   end
 
   describe "#cancel!" do

--- a/spec/models/identity/email_change_request_spec.rb
+++ b/spec/models/identity/email_change_request_spec.rb
@@ -187,8 +187,10 @@ RSpec.describe Identity::EmailChangeRequest do
       expect(activity.parameters[:new_email]).to eq("new@hackclub.com")
     end
     
-    it "reprovisions Slack after completion" do
-      expect(SCIMService).to recieve(:reprovision_identity_after_primary_email_change) do |identity:|
+    it "invokes Slack reprovisioning via the after_commit callback" do
+      expect(SCIMService)
+      .to recieve(:reprovision_identity_after_primary_email_change)
+      .once do |identity:|
         expect(identity.primary_email). to eq("new@hackclub.com")
       end
       
@@ -197,16 +199,18 @@ RSpec.describe Identity::EmailChangeRequest do
     end
 
     it "still completes if Slack reprovisioning raises" do
-      scenario = instance_double("OnboardingScenarios::Base")
-      allow(request.identity).to recieve(:onboarding_scenario_instance).and_return(scenario)
-      allow(SCIMService).to receive(:find_or_create_user).and_raise(StandardError, "Slack is down")
+      oringinal_slack_id = idenity.slack_id
+      allow(SCIMService).to receive(:reprovision_identity_after_primary_email_change).and_raise(StandardError, "Slack is down")
+      expect {
+        request.verify_old_email!(request.old_email_token)
+        request.verify_new_email!(request.new_email_token)
+      }.not_to raise_error
 
-      original_slack_id = identity.slack_id
-
-      request.verify_old_email!(request.old_email_token)
-      request.verify_new_email!(request.new_email_token)
-
-      expect(request.reload).to be_completed
+      request.reload
+      idenity.reload
+      
+      expect(request).to be_completed
+      expect(request.completed_at).to be_present
       expect(identity.reload.primary_email).to eq("new@hackclub.com")
       expect(identity.reload.slack_id).to eq(original_slack_id)
     end 


### PR DESCRIPTION
# Re-provision Slack after primary email changes
## What this PR does
When a user changes their primary email, we now reprovision their Slack account after the email change is completed.
The reprovisioning logic:

- Keeps the current Slack account if it's still the correct one.
- Links an existing Slack account if one already exists for the new email.
- Creates a new Slack account if needed.
- Handles failures gracefully without interrupting the email change process.

## Tests
- Added specs covering:
- Keeping the same Slack account.
- Linking a different existing Slack account.
- Creating a new Slack account.
- Handling reprovisioning failures.
- Ensuring email changes still complete even if Slack reprovisioning fails.

# Why?
I originally had a Slack account with email A. Later that account got deactivated. Before joining Slack again, I changed my primary email in Hack Club Auth to email B.

Then I clicked Join Slack. `SCIMService.find_or_create_user` gets called from both `LoginsController` and `SamlController`:
```
SCIMService.find_or_create_user(
  identity: current_identity,
  scenario: scenario
)
```
Inside `app/services/scim_service.rb`, it looks for an existing Slack user using the current primary email:
```
email = identity.primary_email
existing_slack_id = find_existing_user_by_email(email)
```
and find_existing_user_by_email does:
```
req.params["filter"] = "emails eq \"#{email}\""
```
Since my HCA email was now email B, it looked for a Slack account with email B. My old Slack account still had email A, so it couldn't find it and instead created a completely new Slack account.

After that, HCA saved the new Slack ID to my identity.

Later I changed my HCA email back to email A and my old Slack account was reactivated. But SAML still logged me into the new account because it only provisions if `slack_id` is missing:
```
return if current_identity.slack_id.present?
```

So it never tried to find my original account again.

I think the main issue is that provisioning only looks at the current email the first time. If someone changes their email before provisioning, it's really easy to accidentally create a duplicate Slack account that stays linked forever.