### PR TITLE
fix(oauth): make oauth app edit ui perm-consistent

### DIFF
--- a/app/views/developer_apps/edit.html.erb
+++ b/app/views/developer_apps/edit.html.erb
@@ -33,11 +33,13 @@
         <%= f.label :name, t(".app_name") %>
         <%= f.text_field :name, required: true %>
       </div>
-      <div class="field-group">
-        <%= f.label :redirect_uri, t(".redirect_uri") %>
-        <%= f.text_area :redirect_uri, rows: 3, required: true %>
-        <small class="usn"><%= t ".redirect_uri_hint" %></small>
-      </div>
+      <% if policy(@app).update_redirect_uri? %>
+        <div class="field-group">
+          <%= f.label :redirect_uri, t(".redirect_uri") %>
+          <%= f.text_area :redirect_uri, rows: 3, required: true %>
+          <small class="usn"><%= t ".redirect_uri_hint" %></small>
+        </div>
+      <% end %>
     </section>
 
     <%# === Cards 2+3 wrapped in Alpine === %>


### PR DESCRIPTION
a one line change which hides the redirect uri box in the 'edit app' menu for invited collaborators. 

i was banging my head against my computer for a while trying to figure out why certain oauth apps allowed me to set the redirect url but finally realized that collaborators' ability to modify the field was removed in commit f6d90d439bfdae74be4b4e61bddebf430d62286b.

 this pr just makes the frontend ui consistent with the new gating behavior as well as the already-conditional visibility of the 'rotate secret' button