### PR TITLE
[passkey] nag people into passkeys

### DIFF
--- a/app/components/auth_welcome.rb
+++ b/app/components/auth_welcome.rb
@@ -74,6 +74,45 @@ class Components::AuthWelcome < Components::Base
           plain "→"
         end
       end
+
+      render_passkey_login
+    end
+  end
+
+  def render_passkey_login
+    div(x_data: "passkeyLogin") do
+      div(x_show: "browserSupported", x_cloak: true) do
+        div(style: "display: flex; align-items: center; gap: 0.75rem; margin: 0 0 0.5rem; color: var(--muted-color);") do
+          hr(style: "flex: 1; border: none; border-top: 1px solid var(--border-color); margin: 0;")
+          small(style: "margin: 0;") { t("logins.new.or") }
+          hr(style: "flex: 1; border: none; border-top: 1px solid var(--border-color); margin: 0;")
+        end
+
+        div(x_show: "error", x_cloak: true, class: "alert alert-error", role: "alert") do
+          p(x_text: "error")
+        end
+
+        form(action: passkey_login_verify_path, method: "post", id: "passkey-login-form") do
+          input(type: "hidden", name: "authenticity_token", value: form_authenticity_token)
+          input(type: "hidden", name: "credential_data", id: "passkey-login-credential-data")
+          input(type: "hidden", name: "return_to", value: @return_to)
+        end
+
+        button(
+          type: "button",
+          class: "webauthn-button secondary",
+          style: "width: 100%;",
+          x_on: { click: "login()" },
+          x_bind: { disabled: "loading" }
+        ) do
+          span(class: "webauthn-icon") { inline_icon("fingerprint", size: 16) }
+          span(x_show: "!loading") { t("passkey_login.button") }
+          span(x_show: "loading", x_cloak: true) do
+            plain t("passkey_login.signing_in")
+            plain "..."
+          end
+        end
+      end
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -3,9 +3,15 @@ class ApplicationController < ActionController::Base
   include SessionsHelper
   include StepUpAuthenticatable
 
-  helper_method :current_identity, :identity_signed_in?, :current_onboarding_step, :current_user
+  helper_method :current_identity, :identity_signed_in?, :current_onboarding_step, :current_user, :show_passkey_promotion?
 
   def current_user = nil # TODO: this is a temp hack to fix partials until /backend auth is replaced
+
+  def show_passkey_promotion?
+    current_identity.present? &&
+      current_identity.passkey_promotion_allowed? &&
+      !session[:passkey_promotion_dismissed]
+  end
 
   helper_method :detected_country_alpha2
 
@@ -111,4 +117,13 @@ class ApplicationController < ActionController::Base
   private
 
   def touch_session_last_seen_at = current_session&.touch_last_seen_at
+
+  # Route eligible identities through the passkey setup step.
+  def redirect_with_passkey_prompt(destination)
+    if show_passkey_promotion?
+      redirect_to(passkey_setup_path(return_to: destination))
+    else
+      redirect_to destination
+    end
+  end
 end

--- a/app/controllers/concerns/step_up_authenticatable.rb
+++ b/app/controllers/concerns/step_up_authenticatable.rb
@@ -12,6 +12,8 @@ module StepUpAuthenticatable
     email_available = !action_type.to_s.in?(StepUpController::ACTIONS_WITHOUT_EMAIL_FALLBACK)
     return unless has_2fa || email_available
     return if current_session.recently_stepped_up?(for_action: action_type)
+    # A recent login counts as re-auth for adding a passkey.
+    return if action_type.to_s == "add_passkey" && current_session&.recently_authenticated?
 
     redirect_to new_step_up_path(action_type: action_type, return_to: return_to || request.fullpath)
     false

--- a/app/controllers/concerns/webauthn_authenticatable.rb
+++ b/app/controllers/concerns/webauthn_authenticatable.rb
@@ -16,6 +16,19 @@ module WebauthnAuthenticatable
     options
   end
 
+  # Verify a discoverable passkey without a prior identity (passkey-first sign in).
+  def find_and_verify_discoverable_webauthn_credential(credential_data, session_key:)
+    webauthn_credential = WebAuthn::Credential.from_get(credential_data)
+
+    credential = Identity::WebauthnCredential.active.find_by(
+      external_id: Base64.urlsafe_encode64(webauthn_credential.id, padding: false)
+    )
+
+    return nil unless credential
+
+    verify_webauthn_credential(credential.identity, credential_data:, session_key:)
+  end
+
   def verify_webauthn_credential(identity, credential_data:, session_key:)
     # Delete challenge before parsing to prevent reuse on parse failure
     stored_challenge = session.delete(session_key)

--- a/app/controllers/identity_webauthn_credentials_controller.rb
+++ b/app/controllers/identity_webauthn_credentials_controller.rb
@@ -1,7 +1,9 @@
 class IdentityWebauthnCredentialsController < ApplicationController
   include WebauthnAuthenticatable
+  include SafeUrlValidation
 
-  before_action -> { require_step_up("add_passkey", return_to: security_path) }, only: [ :new, :options, :create ]
+  before_action -> { require_step_up("add_passkey", return_to: security_path) }, only: [ :new ]
+  before_action -> { require_step_up("add_passkey", return_to: passkey_setup_path(return_to: params[:return_to])) }, only: [ :options, :create ]
 
   def index
     @webauthn_credentials = current_identity.webauthn_credentials.order(created_at: :desc)
@@ -22,7 +24,7 @@ class IdentityWebauthnCredentialsController < ApplicationController
       exclude: current_identity.webauthn_credentials.raw_credential_ids,
       authenticator_selection: {
         user_verification: "required",
-        resident_key: "preferred"
+        resident_key: "required"
       }
     )
 
@@ -57,7 +59,7 @@ class IdentityWebauthnCredentialsController < ApplicationController
 
       TwoFactorMailer.authentication_method_enabled(current_identity).deliver_later
       flash[:success] = t(".successfully_added")
-      redirect_to security_path
+      redirect_to url_from(params[:return_to]) || security_path
     rescue WebAuthn::Error => e
       Rails.logger.error "WebAuthn registration error: credential creation failed"
       flash[:error] = "Passkey registration failed. Please try again."

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -340,13 +340,9 @@ class LoginsController < ApplicationController
                 redirect_to root_path
             end
         else
-        flash[:success] = "Logged in!"
-        safe_return_to = @attempt.return_to
-        begin
-          redirect_to safe_return_to.presence || root_path
-        rescue ActionController::Redirecting::UnsafeRedirectError
-          redirect_to root_path
-        end
+            flash[:success] = "Logged in!"
+            destination = url_from(@attempt.return_to) || root_path
+            redirect_with_passkey_prompt(destination)
         end
     end
 

--- a/app/controllers/passkey_logins_controller.rb
+++ b/app/controllers/passkey_logins_controller.rb
@@ -1,0 +1,75 @@
+class PasskeyLoginsController < ApplicationController
+  include WebauthnAuthenticatable
+  include SafeUrlValidation
+  include AhoyAnalytics
+
+  skip_before_action :authenticate_identity!
+  before_action :ensure_no_user!
+
+  PASSKEY_LOGIN_SESSION_KEY = :passkey_login_challenge
+
+  def options
+    options = WebAuthn::Credential.options_for_get(
+      allow: [],
+      user_verification: "required"
+    )
+
+    session[PASSKEY_LOGIN_SESSION_KEY] = options.challenge
+    render json: options
+  end
+
+  def verify
+    credential_data = JSON.parse(params[:credential_data])
+
+    credential = find_and_verify_discoverable_webauthn_credential(
+      credential_data,
+      session_key: PASSKEY_LOGIN_SESSION_KEY
+    )
+
+    unless credential
+      flash[:error] = "Passkey not found. Try using your email instead."
+      redirect_to login_path(return_to: params[:return_to])
+      return
+    end
+
+    identity = credential.identity
+
+    attempt = LoginAttempt.create!(
+      identity: identity,
+      authentication_factors: { webauthn: true },
+      provenance: "login",
+      next_action: "home",
+      return_to: url_from(params[:return_to])
+    )
+
+    attempt.mark_complete! if attempt.may_mark_complete?
+
+    unless attempt.complete?
+      flash[:error] = "Unable to complete authentication"
+      redirect_to login_path(return_to: params[:return_to])
+      return
+    end
+
+    ident_session = sign_in(identity: identity)
+    attempt.update!(session: ident_session)
+
+    track_event(
+      "login.completed",
+      has_mfa: identity.use_two_factor_authentication?,
+      next_action: attempt.next_action,
+      scenario: nil
+    )
+
+    flash[:success] = "Logged in!"
+    redirect_to url_from(params[:return_to]) || root_path
+  rescue WebauthnCredentialCompromisedError
+    flash[:error] = "Security issue detected with your passkey. It has been disabled for your protection. Please use another login method or register a new passkey."
+    redirect_to login_path(return_to: params[:return_to])
+  rescue WebAuthn::Error
+    flash[:error] = "Passkey verification failed. Please try again or use your email."
+    redirect_to login_path(return_to: params[:return_to])
+  rescue JSON::ParserError
+    flash[:error] = "Something went wrong. Please try again."
+    redirect_to login_path(return_to: params[:return_to])
+  end
+end

--- a/app/controllers/passkey_setups_controller.rb
+++ b/app/controllers/passkey_setups_controller.rb
@@ -1,0 +1,27 @@
+class PasskeySetupsController < ApplicationController
+  include SafeUrlValidation
+
+  layout "logged_out"
+
+  before_action :redirect_unless_eligible, only: :show
+
+  def show
+    @return_to = url_from(params[:return_to])
+  end
+
+  def skip
+    session[:passkey_promotion_dismissed] = true
+    current_identity.dismiss_passkey_promotion! if params[:dont_show_again] == "true"
+    redirect_to destination
+  end
+
+  private
+
+  def redirect_unless_eligible
+    redirect_to destination unless show_passkey_promotion?
+  end
+
+  def destination
+    url_from(params[:return_to]) || root_path
+  end
+end

--- a/app/frontend/js/alpine.js
+++ b/app/frontend/js/alpine.js
@@ -2,11 +2,15 @@ import Alpine from 'alpinejs'
 import { webauthnRegister } from './webauthn-registration.js'
 import { webauthnAuth } from './webauthn-authentication.js'
 import { stepUpWebauthn } from './webauthn-step-up.js'
+import { passkeyLogin } from './passkey-login.js'
+import { passkeySetup } from './passkey-setup.js'
 import { scopeEditor } from './scope-editor.js'
 
 Alpine.data('webauthnRegister', webauthnRegister)
 Alpine.data('webauthnAuth', webauthnAuth)
 Alpine.data('stepUpWebauthn', stepUpWebauthn)
+Alpine.data('passkeyLogin', passkeyLogin)
+Alpine.data('passkeySetup', passkeySetup)
 Alpine.data('scopeEditor', scopeEditor)
 
 window.Alpine = Alpine

--- a/app/frontend/js/passkey-login.js
+++ b/app/frontend/js/passkey-login.js
@@ -1,0 +1,89 @@
+export function passkeyLogin() {
+    return {
+        loading: false,
+        error: null,
+        browserSupported: true,
+
+        init() {
+            this.browserSupported = !!(
+                globalThis.PublicKeyCredential?.parseRequestOptionsFromJSON &&
+                navigator.credentials?.get
+            );
+        },
+
+        async login() {
+            this.loading = true;
+            this.error = null;
+
+            try {
+                const response = await fetch('/passkey/login/options', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content
+                    }
+                });
+
+                if (!response.ok) {
+                    throw new Error('Failed to get authentication options from server');
+                }
+
+                const contentType = response.headers.get('content-type') || '';
+                if (!contentType.includes('application/json')) {
+                    window.location.href = response.url;
+                    return;
+                }
+
+                const options = await response.json();
+                const publicKey = PublicKeyCredential.parseRequestOptionsFromJSON(options);
+                const credential = await navigator.credentials.get({ publicKey });
+
+                if (!credential) {
+                    throw new Error('Authentication failed - no credential returned');
+                }
+
+                const responseData = credential.response;
+                const toBase64Url = (buffer) => {
+                    return btoa(String.fromCharCode(...new Uint8Array(buffer)))
+                        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+                };
+                const credentialJSON = {
+                    id: credential.id,
+                    rawId: toBase64Url(credential.rawId),
+                    type: credential.type,
+                    response: {
+                        clientDataJSON: toBase64Url(responseData.clientDataJSON),
+                        authenticatorData: toBase64Url(responseData.authenticatorData),
+                        signature: toBase64Url(responseData.signature),
+                        userHandle: responseData.userHandle ? toBase64Url(responseData.userHandle) : null,
+                    },
+                    clientExtensionResults: credential.getClientExtensionResults(),
+                };
+
+                const credentialDataField = document.getElementById('passkey-login-credential-data');
+                const form = document.getElementById('passkey-login-form');
+
+                if (!credentialDataField || !form) {
+                    throw new Error('Form elements not found');
+                }
+
+                credentialDataField.value = JSON.stringify(credentialJSON);
+                form.submit();
+            } catch (error) {
+                console.error('Passkey login error:', error);
+
+                if (error.name === 'NotAllowedError') {
+                    this.error = 'Sign in was cancelled or not allowed';
+                } else if (error.name === 'InvalidStateError') {
+                    this.error = 'No passkey found for this account';
+                } else if (error.name === 'NotSupportedError') {
+                    this.error = 'Passkeys are not supported on this device';
+                } else {
+                    this.error = error.message || 'An unexpected error occurred';
+                }
+
+                this.loading = false;
+            }
+        }
+    };
+}

--- a/app/frontend/js/passkey-setup.js
+++ b/app/frontend/js/passkey-setup.js
@@ -1,0 +1,97 @@
+export function passkeySetup() {
+    return {
+        loading: false,
+        error: null,
+        dontShowAgain: false,
+        browserSupported: true,
+
+        init() {
+            this.browserSupported = !!(
+                globalThis.PublicKeyCredential?.parseCreationOptionsFromJSON &&
+                navigator.credentials?.create
+            );
+
+            if (!this.browserSupported) {
+                const params = new URLSearchParams(window.location.search);
+                const returnTo = params.get('return_to');
+                window.location.href = returnTo && returnTo.startsWith('/') ? returnTo : '/';
+            }
+        },
+
+        async setup() {
+            this.loading = true;
+            this.error = null;
+
+            try {
+                const params = new URLSearchParams(window.location.search);
+                const returnTo = params.get('return_to');
+                const url = returnTo ? `/passkeys/options?return_to=${encodeURIComponent(returnTo)}` : '/passkeys/options';
+                const response = await fetch(url, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                        'X-CSRF-Token': document.querySelector('meta[name="csrf-token"]')?.content
+                    }
+                });
+
+                if (!response.ok) {
+                    throw new Error('Failed to get registration options from server');
+                }
+
+                const contentType = response.headers.get('content-type') || '';
+                if (!contentType.includes('application/json')) {
+                    window.location.href = response.url;
+                    return;
+                }
+
+                const options = await response.json();
+                const publicKey = PublicKeyCredential.parseCreationOptionsFromJSON(options);
+                const credential = await navigator.credentials.create({ publicKey });
+
+                if (!credential) {
+                    throw new Error('Credential creation failed');
+                }
+
+                const responseData = credential.response;
+                const toBase64Url = (buffer) => {
+                    return btoa(String.fromCharCode(...new Uint8Array(buffer)))
+                        .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+                };
+                const credentialJSON = {
+                    id: credential.id,
+                    rawId: toBase64Url(credential.rawId),
+                    type: credential.type,
+                    response: {
+                        clientDataJSON: toBase64Url(responseData.clientDataJSON),
+                        attestationObject: toBase64Url(responseData.attestationObject),
+                    },
+                    clientExtensionResults: credential.getClientExtensionResults(),
+                };
+
+                const credentialDataField = document.getElementById('setup-credential-data');
+                const form = document.getElementById('setup-registration-form');
+
+                if (!credentialDataField || !form) {
+                    throw new Error('Form elements not found');
+                }
+
+                credentialDataField.value = JSON.stringify(credentialJSON);
+                form.submit();
+            } catch (error) {
+                console.error('Passkey setup error:', error);
+
+                if (error.name === 'NotAllowedError') {
+                    this.error = 'Setup was cancelled or not allowed';
+                } else if (error.name === 'InvalidStateError') {
+                    this.error = 'This passkey is already registered';
+                } else if (error.name === 'NotSupportedError') {
+                    this.error = 'Passkeys are not supported on this device';
+                } else {
+                    this.error = error.message || 'An unexpected error occurred';
+                }
+
+                this.loading = false;
+            }
+        }
+    };
+}

--- a/app/models/identity.rb
+++ b/app/models/identity.rb
@@ -21,6 +21,7 @@
 #  ysws_eligible                 :boolean
 #  created_at                    :datetime         not null
 #  updated_at                    :datetime         not null
+#  passkey_prompt_dismissed_at   :datetime
 #  primary_address_id            :bigint
 #  slack_id                      :string
 #
@@ -362,6 +363,14 @@ class Identity < ApplicationRecord
   def backup_codes_enabled? = backup_codes.active.any?
 
   def webauthn_enabled? = webauthn_credentials.active.any?
+
+  def passkey_promotion_allowed?
+    !webauthn_enabled? && passkey_prompt_dismissed_at.nil?
+  end
+
+  def dismiss_passkey_promotion!
+    update!(passkey_prompt_dismissed_at: Time.current)
+  end
 
   # Encode identity ID as base64url for WebAuthn user.id
   # Uses 64-bit unsigned big-endian binary format

--- a/app/models/identity_session.rb
+++ b/app/models/identity_session.rb
@@ -46,6 +46,10 @@ class IdentitySession < ApplicationRecord
 
   STEP_UP_DURATION = 15.minutes
 
+  def recently_authenticated?
+    created_at > STEP_UP_DURATION.ago
+  end
+
   def recently_stepped_up?(for_action: nil)
     return false unless last_step_up_at.present? && last_step_up_at > STEP_UP_DURATION.ago
 

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -21,6 +21,36 @@
       <%= form.submit "#{t('.continue')} →" %>
     <% end %>
 
+    <div x-data="passkeyLogin()">
+      <div x-show="browserSupported" x-cloak>
+        <div style="display: flex; align-items: center; gap: 0.75rem; margin: 0 0 0.5rem; color: var(--muted-color);">
+          <hr style="flex: 1; border: none; border-top: 1px solid var(--border-color); margin: 0;">
+          <small style="margin: 0;"><%= t(".or") %></small>
+          <hr style="flex: 1; border: none; border-top: 1px solid var(--border-color); margin: 0;">
+        </div>
+
+        <div x-show="error" x-cloak class="alert alert-error" role="alert">
+          <p x-text="error"></p>
+        </div>
+
+        <%= form_with url: passkey_login_verify_path, method: :post, local: true, id: "passkey-login-form" do |form| %>
+          <%= form.hidden_field :credential_data, id: "passkey-login-credential-data" %>
+          <%= form.hidden_field :return_to, value: params[:return_to] %>
+        <% end %>
+
+        <button
+          type="button"
+          class="webauthn-button secondary"
+          style="width: 100%;"
+          x-on:click="login()"
+          x-bind:disabled="loading">
+          <span class="webauthn-icon"><%= inline_icon("fingerprint", size: 16) %></span>
+          <span x-show="!loading"><%= t(".passkey_login") %></span>
+          <span x-show="loading" x-cloak><%= t(".authenticating") %>...</span>
+        </button>
+      </div>
+    </div>
+
     <footer>
       <p>
         <%= t(".no_account") %>

--- a/app/views/passkey_setups/show.html.erb
+++ b/app/views/passkey_setups/show.html.erb
@@ -1,0 +1,43 @@
+<% content_for :title, t(".title") %>
+<div class="auth-container" x-data="passkeySetup()">
+  <div class="auth-card passkey-setup">
+    <header>
+      <h1><%= t(".title") %></h1>
+      <small><%= t(".subtitle") %></small>
+    </header>
+
+    <div x-show="error" x-cloak class="alert alert-error" role="alert">
+      <strong><%= t(".error_title") %></strong>
+      <p x-text="error"></p>
+    </div>
+
+    <%= form_with url: identity_webauthn_credentials_path, method: :post, local: true, id: "setup-registration-form", style: "display: none;" do |form| %>
+      <%= form.hidden_field :credential_data, id: "setup-credential-data" %>
+      <%= form.hidden_field :return_to, value: @return_to %>
+    <% end %>
+
+    <div class="passkey-prompt">
+      <button
+        type="button"
+        class="webauthn-button"
+        x-on:click="setup()"
+        x-bind:disabled="loading">
+        <span class="webauthn-icon"><%= inline_icon("fingerprint", size: 16) %></span>
+        <span x-show="!loading"><%= t(".setup_button") %></span>
+        <span x-show="loading" x-cloak><%= t(".setting_up") %>...</span>
+      </button>
+    </div>
+
+    <div style="margin-top: 0.75rem;">
+      <%= form_with url: passkey_setup_skip_path(return_to: @return_to), method: :post, local: true do |form| %>
+        <%= form.hidden_field :dont_show_again, "x-bind:value": "dontShowAgain" %>
+        <%= form.submit t(".skip"), class: "secondary" %>
+      <% end %>
+    </div>
+
+    <label style="display: flex; align-items: center; justify-content: center; gap: 0.5rem; width: 100%; margin: 1rem 0 0; font-size: 0.85rem; color: var(--muted-color); cursor: pointer;">
+      <input type="checkbox" x-model="dontShowAgain" style="margin: 0; width: 1rem; height: 1rem;">
+      <%= t(".dont_show_again") %>
+    </label>
+  </div>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -428,6 +428,9 @@ en:
       subtitle: Sign in to Hack Club Auth
       email_label: Email address
       continue: Continue
+      or: or
+      passkey_login: Sign in with a passkey
+      authenticating: Signing in
       no_account: Don't have an account?
       signup: Make one
       free: ", it's free!"
@@ -561,6 +564,18 @@ en:
     remove_confirmation: Are you sure you want to remove this passkey? You won't be able to use it to sign in anymore.
     successfully_added: passkey added!
     successfully_removed: passkey removed!
+  passkey_setups:
+    show:
+      title: Sign in faster with a passkey
+      subtitle: Sign in faster with your face, fingerprint, or PIN
+      error_title: Something went wrong
+      setup_button: Set up a passkey
+      setting_up: Setting up
+      skip: Skip
+      dont_show_again: Don't show again
+  passkey_login:
+    button: Sign in with a passkey
+    signing_in: Signing in
   step_up:
     new:
       title: Gotta confirm it's you...

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -371,6 +371,12 @@ Rails.application.routes.draw do
     end
   end
 
+  post "/passkey/login/options", to: "passkey_logins#options", as: :passkey_login_options
+  post "/passkey/login/verify", to: "passkey_logins#verify", as: :passkey_login_verify
+
+  get "/passkey/setup", to: "passkey_setups#show", as: :passkey_setup
+  post "/passkey/setup/skip", to: "passkey_setups#skip", as: :passkey_setup_skip
+
   # Step-up authentication flow
   get "/step_up", to: "step_up#new", as: :new_step_up
   post "/step_up/verify", to: "step_up#verify", as: :verify_step_up

--- a/db/migrate/20260831000001_add_passkey_prompt_dismissed_at_to_identities.rb
+++ b/db/migrate/20260831000001_add_passkey_prompt_dismissed_at_to_identities.rb
@@ -1,0 +1,5 @@
+class AddPasskeyPromptDismissedAtToIdentities < ActiveRecord::Migration[8.0]
+  def change
+    add_column :identities, :passkey_prompt_dismissed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_07_31_000001) do
+ActiveRecord::Schema[8.0].define(version: 2026_08_31_000001) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -116,6 +116,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_31_000001) do
     t.bigint "identity_id"
     t.string "seen_hints", default: [], array: true
     t.boolean "can_process_deletions", default: false, null: false
+    t.boolean "can_ban", default: false, null: false
     t.index ["identity_id"], name: "index_backend_users_on_identity_id"
   end
 
@@ -318,6 +319,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_31_000001) do
     t.boolean "can_hq_officialize", default: false, null: false
     t.string "persona_account_id"
     t.boolean "disallow_slack", default: false, null: false
+    t.datetime "passkey_prompt_dismissed_at"
     t.index "lower((primary_email)::text)", name: "idx_identities_unique_primary_email", unique: true, where: "(deleted_at IS NULL)"
     t.index ["aadhaar_number_bidx"], name: "index_identities_on_aadhaar_number_bidx", unique: true
     t.index ["deleted_at"], name: "index_identities_on_deleted_at"
@@ -450,6 +452,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_31_000001) do
     t.datetime "last_step_up_at"
     t.string "last_step_up_action"
     t.index ["identity_id"], name: "index_identity_sessions_on_identity_id"
+    t.index ["session_token_bidx"], name: "index_identity_sessions_on_session_token_bidx", unique: true
   end
 
   create_table "identity_tombstone_collisions", force: :cascade do |t|
@@ -483,6 +486,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_07_31_000001) do
     t.datetime "updated_at", null: false
     t.bigint "login_attempt_id"
     t.datetime "invalidated_at"
+    t.string "purpose", default: "login"
     t.index ["identity_id", "login_attempt_id", "code", "used_at"], name: "index_v2_codes_on_identity_attempt_code_used"
     t.index ["identity_id"], name: "index_identity_v2_login_codes_on_identity_id"
     t.index ["login_attempt_id"], name: "index_identity_v2_login_codes_on_login_attempt_id"

--- a/spec/models/identity_session_spec.rb
+++ b/spec/models/identity_session_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe IdentitySession, type: :model do
+  let(:identity) { create(:identity) }
+  let(:identity_session) do
+    identity.sessions.create!(
+      session_token: SecureRandom.hex(32),
+      expires_at: 1.week.from_now
+    )
+  end
+
+  describe "#recently_authenticated?" do
+    it "is true for a session created within the step-up window" do
+      expect(identity_session.recently_authenticated?).to be true
+    end
+
+    it "is false for a session older than the step-up window" do
+      identity_session.update_column(:created_at, IdentitySession::STEP_UP_DURATION.ago - 1.minute)
+
+      expect(identity_session.recently_authenticated?).to be false
+    end
+  end
+end

--- a/spec/models/identity_spec.rb
+++ b/spec/models/identity_spec.rb
@@ -134,4 +134,30 @@ RSpec.describe Identity, type: :model do
       expect(identity.persona_verification_locked?).to be false
     end
   end
+
+  describe "#passkey_promotion_allowed?" do
+    it "is true when no passkey is enrolled and not dismissed" do
+      expect(identity.passkey_promotion_allowed?).to be true
+    end
+
+    it "is false when a passkey is enrolled" do
+      identity.webauthn_credentials.create!(
+        webauthn_id: SecureRandom.random_bytes(32),
+        webauthn_public_key: SecureRandom.random_bytes(65)
+      )
+      expect(identity.passkey_promotion_allowed?).to be false
+    end
+
+    it "is false when the promotion has been dismissed" do
+      identity.update!(passkey_prompt_dismissed_at: Time.current)
+      expect(identity.passkey_promotion_allowed?).to be false
+    end
+  end
+
+  describe "#dismiss_passkey_promotion!" do
+    it "sets the dismissed timestamp" do
+      expect { identity.dismiss_passkey_promotion! }
+        .to change { identity.passkey_prompt_dismissed_at }.from(nil)
+    end
+  end
 end

--- a/spec/requests/passkey_logins_spec.rb
+++ b/spec/requests/passkey_logins_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.describe "PasskeyLogins", type: :request do
+  describe "POST /passkey/login/options" do
+    it "returns authentication options with a challenge" do
+      post passkey_login_options_path
+
+      expect(response).to have_http_status(:ok)
+      body = JSON.parse(response.body)
+      expect(body["challenge"]).to be_present
+    end
+  end
+
+  describe "POST /passkey/login/verify" do
+    let(:identity) { create(:identity) }
+
+    context "when the passkey verifies" do
+      before do
+        credential = identity.webauthn_credentials.create!(
+          webauthn_id: SecureRandom.random_bytes(32),
+          webauthn_public_key: SecureRandom.random_bytes(65)
+        )
+        allow_any_instance_of(PasskeyLoginsController)
+          .to receive(:find_and_verify_discoverable_webauthn_credential)
+          .and_return(credential)
+      end
+
+      it "signs the user in and redirects to the root path" do
+        expect {
+          post passkey_login_verify_path, params: { credential_data: "{}" }
+        }.to change { identity.sessions.count }.by(1)
+
+        expect(response).to redirect_to(root_path)
+        expect(flash[:success]).to eq("Logged in!")
+      end
+
+      it "redirects to a safe return_to" do
+        post passkey_login_verify_path, params: { credential_data: "{}", return_to: "/oauth/authorize?client_id=x" }
+
+        expect(response).to redirect_to("/oauth/authorize?client_id=x")
+      end
+
+      it "ignores an unsafe return_to" do
+        post passkey_login_verify_path, params: { credential_data: "{}", return_to: "https://evil.example.com" }
+
+        expect(response).to redirect_to(root_path)
+      end
+    end
+
+    context "when the passkey does not verify" do
+      before do
+        allow_any_instance_of(PasskeyLoginsController)
+          .to receive(:find_and_verify_discoverable_webauthn_credential)
+          .and_return(nil)
+      end
+
+      it "redirects back to login with an error and no session" do
+        expect {
+          post passkey_login_verify_path, params: { credential_data: "{}" }
+        }.not_to change { IdentitySession.count }
+
+        expect(response).to redirect_to(login_path)
+        expect(flash[:error]).to eq("Passkey not found. Try using your email instead.")
+      end
+    end
+  end
+
+  describe "GET /login" do
+    it "offers passkey sign in" do
+      get login_path
+
+      expect(response.body).to include("Sign in with a passkey")
+      expect(response.body).to include("passkey-login-form")
+    end
+  end
+
+  describe "GET /welcome" do
+    it "offers passkey sign in" do
+      allow_any_instance_of(ApplicationController).to receive(:current_identity).and_return(nil)
+      allow_any_instance_of(ApplicationController).to receive(:identity_signed_in?).and_return(false)
+      Rails.application.config.git_version = nil # skip the pre-existing footer bug
+
+      get welcome_path
+
+      expect(response.body).to include("Sign in with a passkey")
+      expect(response.body).to include("passkey-login-form")
+    end
+  end
+end

--- a/spec/requests/passkey_prompt_flow_spec.rb
+++ b/spec/requests/passkey_prompt_flow_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+RSpec.describe "Passkey prompt routing", type: :request do
+  let(:identity) { create(:identity) }
+
+  def login_with_code(return_to: nil)
+    attempt = LoginAttempt.create!(
+      identity: identity,
+      authentication_factors: {},
+      provenance: "login",
+      next_action: "home",
+      return_to: return_to
+    )
+    code = Identity::V2LoginCode.generate(identity)
+    post verify_login_attempt_path(attempt.to_param), params: { code: code.code }
+  end
+
+  it "routes an eligible identity through the passkey setup step" do
+    login_with_code
+
+    expect(response).to redirect_to(passkey_setup_path(return_to: "/"))
+  end
+
+  it "preserves the return_to (e.g. OAuth) through the setup step" do
+    login_with_code(return_to: "/oauth/authorize?client_id=test")
+
+    expect(response).to redirect_to(passkey_setup_path(return_to: "/oauth/authorize?client_id=test"))
+  end
+
+  it "sends a passkey holder straight to the destination" do
+    identity.webauthn_credentials.create!(
+      webauthn_id: SecureRandom.random_bytes(32),
+      webauthn_public_key: SecureRandom.random_bytes(65)
+    )
+
+    login_with_code
+
+    expect(response).to redirect_to("/")
+  end
+
+  it "sends a dismissed identity straight to the destination" do
+    identity.dismiss_passkey_promotion!
+
+    login_with_code
+
+    expect(response).to redirect_to("/")
+  end
+end

--- a/spec/requests/passkey_setups_spec.rb
+++ b/spec/requests/passkey_setups_spec.rb
@@ -1,0 +1,80 @@
+require "rails_helper"
+
+RSpec.describe "PasskeySetups", type: :request do
+  let(:identity) { create(:identity) }
+  let(:identity_session) do
+    identity.sessions.create!(
+      session_token: SecureRandom.hex(32),
+      expires_at: 1.week.from_now
+    )
+  end
+
+  before do
+    allow_any_instance_of(ApplicationController).to receive(:current_identity).and_return(identity)
+    allow_any_instance_of(ApplicationController).to receive(:current_session).and_return(identity_session)
+    allow_any_instance_of(ApplicationController).to receive(:identity_signed_in?).and_return(true)
+  end
+
+  describe "GET /passkey/setup" do
+    it "renders the setup prompt for an eligible identity" do
+      get passkey_setup_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("Sign in faster with a passkey")
+      expect(response.body).to include("setup-registration-form")
+      expect(response.body).to include("show again")
+      expect(response.body).to include("Skip")
+      expect(response.body).to include("auth-page")
+    end
+
+    it "redirects to the return_to when the identity already has a passkey" do
+      identity.webauthn_credentials.create!(
+        webauthn_id: SecureRandom.random_bytes(32),
+        webauthn_public_key: SecureRandom.random_bytes(65)
+      )
+
+      get passkey_setup_path, params: { return_to: "/security" }
+
+      expect(response).to redirect_to("/security")
+    end
+
+    it "redirects to root when the promotion has been dismissed" do
+      identity.dismiss_passkey_promotion!
+
+      get passkey_setup_path
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  describe "POST /passkeys/options" do
+    it "allows registration without a step-up when the session is recent" do
+      post options_identity_webauthn_credentials_path
+
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)).to include("challenge")
+    end
+  end
+
+  describe "POST /passkey/setup/skip" do
+    it "dismisses for the session and redirects to the return_to" do
+      post passkey_setup_skip_path, params: { return_to: "/" }
+
+      expect(session[:passkey_promotion_dismissed]).to be true
+      expect(response).to redirect_to("/")
+    end
+
+    it "does not persist the dismissal" do
+      post passkey_setup_skip_path, params: { return_to: "/" }
+
+      expect(identity.reload.passkey_prompt_dismissed_at).to be_nil
+    end
+
+    it "persists the dismissal when the don't show again toggle is checked" do
+      post passkey_setup_skip_path, params: { return_to: "/", dont_show_again: "true" }
+
+      expect(identity.reload.passkey_prompt_dismissed_at).to be_present
+      expect(response).to redirect_to("/")
+    end
+  end
+end


### PR DESCRIPTION
Adds a proper passkey push:

- setup step after email-code login/signup/oauth
- dedicated "Sign in with a passkey" button on /login, /welcome, /oauth_welcome. some password managers like 1Password can offer passkey sign-in on their own when they detect one, but a dedicated button is best practice, it also picks up Apple Passwords and other platform passkeys
- only shown in WebAuthn-capable browsers
- no second email code when adding a passkey right after login (a session younger than 15 min counts as re-auth for add_passkey)

code stuff:
- one new migration, adds identities.passkey_prompt_dismissed_at
- schema.rb also shows can_ban, v2_login_codes.purpose and an identity_sessions index — those come from older commits that never made it into schema.rb, not part of this PR, but they have to be there or schema.rb doesn't match the migrations
- new passkey_logins controller: passkey-first login with no email, finds your account from the passkey itself
- new passkey_setups controller: the setup step page
- passkeys now register as discoverable (resident_key: required) so they work for passkey-first login
- login completion routes eligible people to the setup step instead of straight home