### PR TITLE
Disable MCGs in onboarding flows

### DIFF
--- a/app/models/onboarding_scenarios/base.rb
+++ b/app/models/onboarding_scenarios/base.rb
@@ -1,5 +1,12 @@
 module OnboardingScenarios
   class Base
+
+    FORCE_FULL_MEMBER = true
+
+    module ForceFullMember
+      def slack_user_type = :full_member
+    end
+
     class << self
       # Optional slug for /join/:slug routing. Default: no slug
       def slug = nil
@@ -11,6 +18,11 @@ module OnboardingScenarios
 
       def available_slugs
         descendants&.filter_map(&:slug)&.sort || []
+      end
+
+      def inherited(subclass)
+        super
+        subclass.prepend(ForceFullMember) if FORCE_FULL_MEMBER
       end
     end
 

--- a/spec/models/onboarding_scenarios/flavortown_spec.rb
+++ b/spec/models/onboarding_scenarios/flavortown_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe OnboardingScenarios::Flavortown do
   end
 
   describe "slack configuration" do
-    it "uses multi-channel guest type" do
-      expect(scenario.slack_user_type).to eq(:multi_channel_guest)
+    it "is forced to full member (MCG provisioning disabled workspace-wide)" do
+      expect(scenario.slack_user_type).to eq(:full_member)
     end
 
     it "does not use DM channel" do


### PR DESCRIPTION
 Forces every onboarding scenarios slack_user_type to :full_member hard disabling MCG's provisioning workspace wide.